### PR TITLE
Remove sudo from init script

### DIFF
--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -98,7 +98,7 @@ function set_values () {
     # Tabs url_redirect
     sed -i -e "s@_MONITOR_URL_@$MONITOR_URL@g" /etc/nginx/nginx.conf
     sed -i -e "s@_SECURE_URL_@$SECURE_URL@g" /etc/nginx/nginx.conf
-    sudo systemctl restart nginx
+    systemctl restart nginx
 }
 
 ##


### PR DESCRIPTION
The script is meant to be run by user root. `sudo` is an unneeded dependency.