### PR TITLE
persist deploy date

### DIFF
--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -283,7 +283,8 @@ function intro () {
 ##
 function deploy_agent () {
     AGENT_DEPLOY_DATE=$(date -d '+2 hour' +"%F__%H_%M")
-
+    echo ${AGENT_DEPLOY_DATE} > $WORK_DIR/agent_deploy_date
+    
     echo "Configuring Sysdig Agent"
     echo -e "  Visit ${F_BOLD}${F_CYAN}$MONITOR_URL/#/settings/agentInstallation${F_CLEAR} to retrieve your Sysdig Agent Key."
     read -p "  Insert your Sysdig Agent Key: " AGENT_ACCESS_KEY;


### PR DESCRIPTION
We use the `AGENT_DEPLOY_DATE` to tag agent with `cluster` information. I want to have this information persisted in the lab to use it when required. For example, my custom events.