### PR TITLE
[instruqt-setup-script] support install for cloudVision Terraform installer + isolate option to set region for track's sysdig tab

### DIFF
--- a/common/prepare-track/README.md
+++ b/common/prepare-track/README.md
@@ -22,13 +22,16 @@ in production.
 OPTIONS:
 
   -a, --agent                 Deploy a Sysdig Agent.
+  -c, --cloud                 Set up environment for Sysdig Secure for Cloud.
   -h, --help                  Show this help.
   -m, --monitor               Set up environment for Monitor API usage.
   -n, --node-analyzer         Enable Node Analyzer. Use with -a/--agent.
   -N, --node-image-analyzer   Enable Image Node Analyzer. Use with -a/--agent.
   -p, --prometheus            Enable Prometheus. Use with -a/--agent.
   -s, --secure                Set up environment for Secure API usage.
-
+  -r, --region                Set up environment with user's Sysdig Region for a track with a host.
+  -q, --region-cloud          Set up environment with user's Sysdig Region for cloud track with a cloud account.
+  -v, --vulnmanag             Enable Image Scanning with Sysdig Secure for Cloud. Use with -c/--cloud.
 
 ENVIRONMENT VARIABLES:
 
@@ -43,4 +46,5 @@ ENVIRONMENT VARIABLES:
   DOCKER_OPTS                 Additional options for Docker installation.
 
   HOST_OPTS                   Additional options for Host installation.
+
 ```

--- a/common/prepare-track/README.md
+++ b/common/prepare-track/README.md
@@ -7,16 +7,15 @@ USAGE:
   init.sh [OPTIONS...]
 
 
-Environment start up script. It can be used to deploy a Sysdig Agent and/or set
-up some environment variables. When called with NO OPTIONS, it will deploy an
-Agent and will ask for Monitor and Secure API keys; same as calling with
-'-a/--agent -m/--monitor -s/--secure'. When using the product options"
-('-m/--monitor' and/or '-s/--secure'), API keys will be stored in file
-/opt/sysdig/user_data_${PRODUCT}_API_OK, and exported to envvar
-$SYSDIG_${PRODUCT}_API_TOKEN (where ${PRODUCT} is MONITOR or SECURE).
+Environment start up script. It can be used to:
+- deploy a Sysdig Agent 
+- deploy Sysdig Secure for Cloud (AWS, GCP, Azure)
+- and/or set up some environment variables.
 
-WARNING: This script is meant to be used in training materials. Do NOT use it
-in production.
+Review the options below to learn what's available.
+
+WARNING: This script is meant to be used in training materials.
+Do NOT use it in production.
 
 
 OPTIONS:

--- a/common/prepare-track/cloud/aws/cloud-connector-aws.tf
+++ b/common/prepare-track/cloud/aws/cloud-connector-aws.tf
@@ -32,4 +32,7 @@ provider "aws" {
 
 module "secure-for-cloud_example_single-account" {
   source = "sysdiglabs/secure-for-cloud/aws//examples/single-account"
+
+  # deploy_beta_image_scanning_ecr=true
+
 }

--- a/common/prepare-track/cloud/aws/cloud-connector-aws.tf
+++ b/common/prepare-track/cloud/aws/cloud-connector-aws.tf
@@ -21,6 +21,11 @@ variable "training_aws_region" {
   description = "The AWS Region"
 }
 
+variable "deploy_scanner" {
+  type        = bool
+  description = "If true, deploys the Sysdig Scanner for ECR and Fargate"
+}
+
 provider "sysdig" {
   sysdig_secure_url       = var.training_secure_url
   sysdig_secure_api_token = var.training_secure_api_token
@@ -33,6 +38,7 @@ provider "aws" {
 module "secure-for-cloud_example_single-account" {
   source = "sysdiglabs/secure-for-cloud/aws//examples/single-account"
 
-  # deploy_beta_image_scanning_ecr=true
-
+  deploy_image_scanning_ecs = var.deploy_scanner
+  deploy_image_scanning_ecr = var.deploy_scanner
+  deploy_beta_image_scanning_ecr = var.deploy_scanner
 }

--- a/common/prepare-track/cloud/aws/cloud-connector-aws.tf
+++ b/common/prepare-track/cloud/aws/cloud-connector-aws.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+      sysdig = {
+        source  = "sysdiglabs/sysdig"
+      }
+  }
+}
+
+variable "training_secure_api_token" {
+  type        = string
+  description = "The Sysdig API token"
+}
+
+variable "training_secure_url" {
+  type        = string
+  description = "The Sysdig Secure URL"
+}
+
+variable "training_aws_region" {
+  type        = string
+  description = "The AWS Region"
+}
+
+provider "sysdig" {
+  sysdig_secure_url       = var.training_secure_url
+  sysdig_secure_api_token = var.training_secure_api_token
+}
+
+provider "aws" {
+  region = var.training_aws_region
+}
+
+module "secure-for-cloud_example_single-account" {
+  source = "sysdiglabs/secure-for-cloud/aws//examples/single-account"
+}

--- a/common/prepare-track/cloud/azure/cloud-connector-azure.tf
+++ b/common/prepare-track/cloud/azure/cloud-connector-azure.tf
@@ -34,7 +34,7 @@ provider "azurerm" {
 module "secure_for_cloud_example_single_subscription" {
   source = "sysdiglabs/secure-for-cloud/azurerm//examples/single-subscription"
 
-  deploy_scanning = true
+  deploy_scanning = false
 
   deploy_active_directory=false
 } 

--- a/common/prepare-track/cloud/azure/cloud-connector-azure.tf
+++ b/common/prepare-track/cloud/azure/cloud-connector-azure.tf
@@ -1,0 +1,40 @@
+terraform {
+  required_providers {
+      sysdig = {
+        source  = "sysdiglabs/sysdig"
+      }
+  }
+}
+
+variable "training_secure_api_token" {
+  type        = string
+  description = "The Sysdig API token"
+}
+
+variable "training_secure_url" {
+  type        = string
+  description = "The Sysdig Secure URL"
+}
+
+variable "training_azure_subscription" {
+  type        = string
+  description = "Azure Subscription ID"
+}
+
+provider "sysdig" {
+  sysdig_secure_url       = var.training_secure_url
+  sysdig_secure_api_token = var.training_secure_api_token
+}
+
+provider "azurerm" {
+  features { }
+  subscription_id = var.training_azure_subscription
+}
+
+module "secure_for_cloud_example_single_subscription" {
+  source = "sysdiglabs/secure-for-cloud/azurerm//examples/single-subscription"
+
+  deploy_scanning = true
+
+  deploy_active_directory=false
+} 

--- a/common/prepare-track/cloud/azure/cloud-connector-azure.tf
+++ b/common/prepare-track/cloud/azure/cloud-connector-azure.tf
@@ -21,6 +21,11 @@ variable "training_azure_subscription" {
   description = "Azure Subscription ID"
 }
 
+variable "deploy_scanner" {
+  type        = bool
+  description = "If true, deploys the Sysdig Scanner for ECR and Fargate"
+}
+
 provider "sysdig" {
   sysdig_secure_url       = var.training_secure_url
   sysdig_secure_api_token = var.training_secure_api_token
@@ -34,7 +39,7 @@ provider "azurerm" {
 module "secure_for_cloud_example_single_subscription" {
   source = "sysdiglabs/secure-for-cloud/azurerm//examples/single-subscription"
 
-  deploy_scanning = false
+  deploy_scanning = var.deploy_scanner
 
-  deploy_active_directory=false
+  deploy_active_directory = false
 } 

--- a/common/prepare-track/cloud/gcp/cloud-connector-gcp.tf
+++ b/common/prepare-track/cloud/gcp/cloud-connector-gcp.tf
@@ -1,0 +1,55 @@
+terraform {
+  required_providers {
+      sysdig = {
+        source  = "sysdiglabs/sysdig"
+      }
+  }
+}
+
+variable "training_secure_api_token" {
+  type        = string
+  description = "The Sysdig API token"
+}
+
+variable "training_secure_url" {
+  type        = string
+  description = "The Sysdig Secure URL"
+}
+
+variable "training_gcp_region" {
+  type        = string
+  description = "The Sysdig Secure Region"
+}
+
+variable "training_gcp_project" {
+  type        = string
+  description = "The Sysdig Secure Region"
+}
+
+variable "gcp_creds" {
+  type        = string
+  description = "Auth credentials for the GCP SA from Instruqt"
+}
+
+provider "sysdig" {
+  sysdig_secure_url       = var.training_secure_url
+  sysdig_secure_api_token = var.training_secure_api_token
+}
+
+provider "google" {
+  project = var.training_gcp_project
+  region = var.training_gcp_region
+  credentials = var.gcp_creds
+}
+
+provider "google-beta" {
+  project = var.training_gcp_project
+  region = var.training_gcp_region
+  credentials = var.gcp_creds
+}
+
+module "secure-for-cloud_example_single-project" {
+  source = "sysdiglabs/secure-for-cloud/google//examples/single-project"
+  
+  deploy_scanning = true
+}

--- a/common/prepare-track/cloud/gcp/cloud-connector-gcp.tf
+++ b/common/prepare-track/cloud/gcp/cloud-connector-gcp.tf
@@ -31,6 +31,11 @@ variable "gcp_creds" {
   description = "Auth credentials for the GCP SA from Instruqt"
 }
 
+variable "deploy_scanner" {
+  type        = bool
+  description = "If true, deploys the Sysdig Scanner for ECR and Fargate"
+}
+
 provider "sysdig" {
   sysdig_secure_url       = var.training_secure_url
   sysdig_secure_api_token = var.training_secure_api_token
@@ -51,5 +56,5 @@ provider "google-beta" {
 module "secure-for-cloud_example_single-project" {
   source = "sysdiglabs/secure-for-cloud/google//examples/single-project"
   
-  deploy_scanning = true
+  deploy_scanning = var.deploy_scanner
 }

--- a/common/prepare-track/cloud/install_with_terraform.sh
+++ b/common/prepare-track/cloud/install_with_terraform.sh
@@ -22,11 +22,15 @@ cd /root/prepare-track/cloud
 if [ "$PROVIDER" == "aws" ]
 then
     cd aws
-    terraform init && terraform apply -auto-approve \
+    echo "  Initializing Terraform modules, backend and provider plugins" \
+    terraform init >> ${OUTPUT} 2>&1 \
+    && echo "    Terraform has been successfully initialized. Applying..." \
+    && terraform apply -auto-approve \
         -var="training_secure_api_token=$SYSDIG_SECURE_API_TOKEN" \
         -var="training_secure_url=$SECURE_URL" \
         -var="training_aws_region=$CLOUD_REGION" \
-        >> ${OUTPUT} 2>&1
+        >> ${OUTPUT} 2>&1 \
+    && echo "    Terraform apply completed! Check all TF deployment logs at: $OUTPUT" \
 fi
 
 if [ "$PROVIDER" == "gcp" ]

--- a/common/prepare-track/cloud/install_with_terraform.sh
+++ b/common/prepare-track/cloud/install_with_terraform.sh
@@ -29,7 +29,7 @@ then
         -var="training_secure_api_token=$SYSDIG_SECURE_API_TOKEN" \
         -var="training_secure_url=$SECURE_URL" \
         -var="training_aws_region=$CLOUD_REGION" \
-        -var="deploy_scanner=$CLOUD_SCAN_ENGINE" \
+        -var="deploy_scanner=$USE_CLOUD_SCAN_ENGINE" \
         >> ${OUTPUT} 2>&1 \
     && echo "    Terraform apply completed! Check all TF deployment logs at: $OUTPUT"
 fi
@@ -46,7 +46,7 @@ then
         -var="training_gcp_region=$CLOUD_REGION" \
         -var="training_gcp_project=$CLOUD_ACCOUNT_ID" \
         -var="gcp_creds=$GOOGLE_CREDENTIALS" \
-        -var="deploy_scanner=$CLOUD_SCAN_ENGINE" \
+        -var="deploy_scanner=$USE_CLOUD_SCAN_ENGINE" \
         >> ${OUTPUT} 2>&1 \
     && echo "    Terraform apply completed! Check all TF deployment logs at: $OUTPUT"
 fi
@@ -58,6 +58,6 @@ then
         -var="training_secure_api_token=$SYSDIG_SECURE_API_TOKEN" \
         -var="training_secure_url=$SECURE_URL" \
         -var="training_azure_subscription=$CLOUD_ACCOUNT_ID" \
-        -var="deploy_scanner=$CLOUD_SCAN_ENGINE" #\
+        -var="deploy_scanner=$USE_CLOUD_SCAN_ENGINE" #\
         #-y >> ${OUTPUT} 2>&1
 fi

--- a/common/prepare-track/cloud/install_with_terraform.sh
+++ b/common/prepare-track/cloud/install_with_terraform.sh
@@ -8,7 +8,7 @@
 
 # logs
 OUTPUT=/opt/sysdig/cloud/terraform_install.out
-mkdir /opt/sysdig/cloud/
+mkdir -p /opt/sysdig/cloud/
 touch $OUTPUT
 
 PROVIDER=$1
@@ -23,14 +23,14 @@ if [ "$PROVIDER" == "aws" ]
 then
     cd aws
     echo "  Initializing Terraform modules, backend and provider plugins" \
-    terraform init >> ${OUTPUT} 2>&1 \
+    && terraform init >> ${OUTPUT} 2>&1 \
     && echo "    Terraform has been successfully initialized. Applying..." \
     && terraform apply -auto-approve \
         -var="training_secure_api_token=$SYSDIG_SECURE_API_TOKEN" \
         -var="training_secure_url=$SECURE_URL" \
         -var="training_aws_region=$CLOUD_REGION" \
         >> ${OUTPUT} 2>&1 \
-    && echo "    Terraform apply completed! Check all TF deployment logs at: $OUTPUT" \
+    && echo "    Terraform apply completed! Check all TF deployment logs at: $OUTPUT"
 fi
 
 if [ "$PROVIDER" == "gcp" ]

--- a/common/prepare-track/cloud/install_with_terraform.sh
+++ b/common/prepare-track/cloud/install_with_terraform.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+##
+# Deploy the Sysdig Cloud Connector for Sysdig Secure for Cloud in AWS
+#
+# Usage:
+#   install_with_terraform.sh $PROVIDER $SYSDIG_SECURE_API_TOKEN $SECURE_URL $CLOUD_REGION $CLOUD_ACCOUNT_ID
+##
+
+OUTPUT=/opt/sysdig/cloud/terraform_install.out
+mkdir /opt/sysdig/cloud/
+touch $OUTPUT
+
+PROVIDER=$1
+SYSDIG_SECURE_API_TOKEN=$2
+SECURE_URL=$3
+CLOUD_REGION=$4
+CLOUD_ACCOUNT_ID=$5
+
+echo "pablo-------------------------------------"
+echo $SYSDIG_SECURE_API_TOKEN
+echo $SECURE_URL
+echo $CLOUD_ACCOUNT_ID
+echo "pablo-------------------------------------"
+
+cd /root/prepare-track/cloud
+
+if [ "$PROVIDER" == "aws" ]
+then
+    cd aws
+    terraform init && terraform apply -auto-approve \
+        -var="training_secure_api_token=$SYSDIG_SECURE_API_TOKEN" \
+        -var="training_secure_url=$SECURE_URL" \
+        -var="training_aws_region=$CLOUD_REGION" #\
+        #-y >> ${OUTPUT} 2>&1
+fi
+
+if [ "$PROVIDER" == "gcp" ]
+then
+    cd gcp
+    terraform init && terraform apply -auto-approve \
+        -var="training_secure_api_token=$SYSDIG_SECURE_API_TOKEN" \
+        -var="training_secure_url=$SECURE_URL" \
+        -var="training_gcp_region=$CLOUD_REGION" \
+        -var="training_gcp_project=$CLOUD_ACCOUNT_ID" \
+        -var="gcp_creds=$GOOGLE_CREDENTIALS" #\
+        #-y >> ${OUTPUT} 2>&1
+fi
+
+if [ "$PROVIDER" == "azure" ]
+then
+    cd azure
+    terraform init && terraform apply -auto-approve \
+        -var="training_secure_api_token=$SYSDIG_SECURE_API_TOKEN" \
+        -var="training_secure_url=$SECURE_URL" \
+        -var="training_azure_subscription=$CLOUD_ACCOUNT_ID" #\
+        #-y >> ${OUTPUT} 2>&1
+fi

--- a/common/prepare-track/cloud/install_with_terraform.sh
+++ b/common/prepare-track/cloud/install_with_terraform.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ##
-# Deploy the Sysdig Cloud Connector for Sysdig Secure for Cloud in AWS
+# Deploy the Sysdig Secure for Cloud infra for different cloud vendors
 #
 # Usage:
 #   install_with_terraform.sh $PROVIDER $SYSDIG_SECURE_API_TOKEN $SECURE_URL $CLOUD_REGION $CLOUD_ACCOUNT_ID
@@ -29,6 +29,7 @@ then
         -var="training_secure_api_token=$SYSDIG_SECURE_API_TOKEN" \
         -var="training_secure_url=$SECURE_URL" \
         -var="training_aws_region=$CLOUD_REGION" \
+        -var="deploy_scanner=$CLOUD_SCAN_ENGINE" \
         >> ${OUTPUT} 2>&1 \
     && echo "    Terraform apply completed! Check all TF deployment logs at: $OUTPUT"
 fi
@@ -45,6 +46,7 @@ then
         -var="training_gcp_region=$CLOUD_REGION" \
         -var="training_gcp_project=$CLOUD_ACCOUNT_ID" \
         -var="gcp_creds=$GOOGLE_CREDENTIALS" \
+        -var="deploy_scanner=$CLOUD_SCAN_ENGINE" \
         >> ${OUTPUT} 2>&1 \
     && echo "    Terraform apply completed! Check all TF deployment logs at: $OUTPUT"
 fi
@@ -55,6 +57,7 @@ then
     terraform init && terraform apply -auto-approve \
         -var="training_secure_api_token=$SYSDIG_SECURE_API_TOKEN" \
         -var="training_secure_url=$SECURE_URL" \
-        -var="training_azure_subscription=$CLOUD_ACCOUNT_ID" #\
+        -var="training_azure_subscription=$CLOUD_ACCOUNT_ID" \
+        -var="deploy_scanner=$CLOUD_SCAN_ENGINE" #\
         #-y >> ${OUTPUT} 2>&1
 fi

--- a/common/prepare-track/cloud/install_with_terraform.sh
+++ b/common/prepare-track/cloud/install_with_terraform.sh
@@ -36,13 +36,17 @@ fi
 if [ "$PROVIDER" == "gcp" ]
 then
     cd gcp
-    terraform init && terraform apply -auto-approve \
+    echo "  Initializing Terraform modules, backend and provider plugins" \
+    && terraform init >> ${OUTPUT} 2>&1 \
+    && echo "    Terraform has been successfully initialized. Applying... (this will take a few minutes)" \
+    && terraform apply -auto-approve \
         -var="training_secure_api_token=$SYSDIG_SECURE_API_TOKEN" \
         -var="training_secure_url=$SECURE_URL" \
         -var="training_gcp_region=$CLOUD_REGION" \
         -var="training_gcp_project=$CLOUD_ACCOUNT_ID" \
-        -var="gcp_creds=$GOOGLE_CREDENTIALS" #\
-        #-y >> ${OUTPUT} 2>&1
+        -var="gcp_creds=$GOOGLE_CREDENTIALS" \
+        >> ${OUTPUT} 2>&1 \
+    && echo "    Terraform apply completed! Check all TF deployment logs at: $OUTPUT"
 fi
 
 if [ "$PROVIDER" == "azure" ]

--- a/common/prepare-track/cloud/install_with_terraform.sh
+++ b/common/prepare-track/cloud/install_with_terraform.sh
@@ -6,6 +6,7 @@
 #   install_with_terraform.sh $PROVIDER $SYSDIG_SECURE_API_TOKEN $SECURE_URL $CLOUD_REGION $CLOUD_ACCOUNT_ID
 ##
 
+# logs
 OUTPUT=/opt/sysdig/cloud/terraform_install.out
 mkdir /opt/sysdig/cloud/
 touch $OUTPUT
@@ -16,12 +17,6 @@ SECURE_URL=$3
 CLOUD_REGION=$4
 CLOUD_ACCOUNT_ID=$5
 
-echo "pablo-------------------------------------"
-echo $SYSDIG_SECURE_API_TOKEN
-echo $SECURE_URL
-echo $CLOUD_ACCOUNT_ID
-echo "pablo-------------------------------------"
-
 cd /root/prepare-track/cloud
 
 if [ "$PROVIDER" == "aws" ]
@@ -30,8 +25,8 @@ then
     terraform init && terraform apply -auto-approve \
         -var="training_secure_api_token=$SYSDIG_SECURE_API_TOKEN" \
         -var="training_secure_url=$SECURE_URL" \
-        -var="training_aws_region=$CLOUD_REGION" #\
-        #-y >> ${OUTPUT} 2>&1
+        -var="training_aws_region=$CLOUD_REGION" \
+        >> ${OUTPUT} 2>&1
 fi
 
 if [ "$PROVIDER" == "gcp" ]

--- a/common/prepare-track/cloud/install_with_terraform.sh
+++ b/common/prepare-track/cloud/install_with_terraform.sh
@@ -24,7 +24,7 @@ then
     cd aws
     echo "  Initializing Terraform modules, backend and provider plugins" \
     && terraform init >> ${OUTPUT} 2>&1 \
-    && echo "    Terraform has been successfully initialized. Applying..." \
+    && echo "    Terraform has been successfully initialized. Applying... (this will take a few minutes)" \
     && terraform apply -auto-approve \
         -var="training_secure_api_token=$SYSDIG_SECURE_API_TOKEN" \
         -var="training_secure_url=$SECURE_URL" \

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -456,7 +456,7 @@ function test_agent () {
 # 
 # More info about resources and variables used in this function:
 #    -----------------------------------------------------------------------------
-#    Instruqt can attach a burner cloud account with a track. It inyects 
+#    Instruqt can attach a burner cloud account with a track. It injects 
 #    credentials to use the account in the host or cloud_container. This
 #    function checks if there's a cloud account in the track and in that case
 #    it sets the requiered env vars to use it and deploy sysdig secure for cloud.

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -565,7 +565,6 @@ function test_cloud_connector () {
         https://secure.sysdig.com/api/cloud/v2/dataSources/accounts\?limit\=50\&offset\=0 \
         | jq '[.[] | {provider: .provider, id: .id, alias: .alias, lastSeen: .cloudConnectorLastSeenAt}] | sort_by(.lastSeen) | reverse | .[] | "\(.provider) \(.id) \(.alias) \(.lastSeen)"' \
         | cut -f1 -d"." \
-        | sed '/null/d' \
         | sed 's/^.//' \
         > .cloudProvidersLastSeen
 
@@ -644,7 +643,8 @@ function clean_setup () {
         # we used to remove these files, but they are useful for debugging.
         # Also, the terraform state file is good to keep it in case we need to destroy the assets
         # In most cases we don't care about this, as Instruqts manages the cleanup of the envs.
-        mv -r $TRACK_DIR/ /tmp/$TRACK_DIR
+        mv $TRACK_DIR/ /tmp/
+        test -f /root/creds.json && mv /root/creds.json /tmp/
         sed -i '/init.sh/d' /root/.profile  # removes the script from .profile so it is not executed in new challenges
         touch $WORK_DIR/user_data_OK # flag environment configured with user data
     else

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -563,9 +563,9 @@ function test_cloud_connector () {
         -H 'Authorization: Bearer '"${SYSDIG_SECURE_API_TOKEN}" \
         --request GET \
         https://secure.sysdig.com/api/cloud/v2/dataSources/accounts\?limit\=50\&offset\=0 \
-        | jq '[.[] | {provider: .provider, id: .id, alias: .alias, lastSeen: .cloudConnectorLastSeenAt}] | sort_by(.lastSeen) | reverse | .[] | "\(.provider) \(.id) \(.alias) \(.lastSeen)"' \
+        | jq -r '[.[] | {provider: .provider, id: .id, alias: .alias, lastSeen: .cloudConnectorLastSeenAt}] | sort_by(.lastSeen) | reverse | .[] | "\(.provider) \(.id) \(.alias) \(.lastSeen)"' \
         | cut -f1 -d"." \
-        | sed 's/^.//' \
+        | awk ' { t = $1; $1 = $(NF); $(NF) = t; print; } ' \
         > .cloudProvidersLastSeen
 
         CLOUD_CONNECTOR_DEPLOY_QUERY_EPOCH=$(date --date "$CLOUD_CONNECTOR_DEPLOY_QUERY" +%s)
@@ -575,7 +575,7 @@ function test_cloud_connector () {
             if [[ "${line}" =~ "${CLOUD_ACCOUNT_ID}" ]]
             then 
                 # the account_id matches
-                LAST_SEEN_DATE=$(echo "$line" | cut -d' ' -f4) # extract date
+                LAST_SEEN_DATE=$(echo "$line" | cut -d' ' -f1) # extract date
                 LAST_SEEN_DATE_EPOCH=$(date --date "$LAST_SEEN_DATE" +%s)
                 # is this account date_last_seen value greater than the deployment_date in this script?
                 # ^ this means, we want the cloud account to be active now

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -494,7 +494,6 @@ function deploy_cloud_connector () {
     
     echo "Configuring Sysdig CloudVision for $CLOUD_PROVIDER"
 
-
     # we are defining here some values (region) but in future we might want the user to choose its region
     # right now there's not a reason to select one or another
     if [ $CLOUD_PROVIDER = "aws" ]

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -492,6 +492,7 @@ function deploy_cloud_connector () {
     CLOUD_CONNECTOR_DEPLOY_QUERY=$(date -d '+1 hour' +"%FT%H:%M:%S")
     CLOUD_REGION=""
     echo ${CLOUD_CONNECTOR_DEPLOY_DATE} > $WORK_DIR/cloud_connector_deploy_date
+    echo ${CLOUD_CONNECTOR_DEPLOY_QUERY} > $WORK_DIR/cloud_connector_deploy_query
     
     echo "Configuring Sysdig CloudVision for $CLOUD_PROVIDER"
 
@@ -518,7 +519,7 @@ function deploy_cloud_connector () {
 # Test if the Cloud account is connected successfully.
 ##
 function test_cloud_connector () {
-    echo "Testing if the cloud account is connected..."
+    echo "    Testing if the cloud account is connected..."
 
     attempt=0
     MAX_ATTEMPTS=60 # 3 minutes
@@ -526,7 +527,7 @@ function test_cloud_connector () {
 
     while [ "$connected" != true ] && [ $attempt -le $MAX_ATTEMPTS ]
     do
-        sleep 30
+        sleep 10
         
         curl -s --header "Content-Type: application/json"   \
         -H 'Authorization: Bearer '"${SYSDIG_SECURE_API_TOKEN}" \
@@ -537,6 +538,8 @@ function test_cloud_connector () {
         | sed '/null/d' \
         | sed 's/^.//' \
         > .cloudProvidersLastSeen
+
+        echo "deploy date: $(cat $WORK_DIR/cloud_connector_deploy_query)"
         echo "list of cloud accounts"
         cat .cloudProvidersLastSeen
         # sed -i -e '/${CLOUD_PROVIDER}/!d' .cloudProvidersLastSeen # remove entries from other cloud providers

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -685,7 +685,7 @@ function help () {
     echo "  -s, --secure                Set up environment for Secure API usage."
     echo "  -r, --region                Set up environment with user's Sysdig Region for a track with a host."
     echo "  -q, --region-cloud          Set up environment with user's Sysdig Region for cloud track with a cloud account."
-    echo "  -v, --vulnmanag             Enable Image Scanning with Sysdig Secure for Cloud. Use with -c/--cloud."
+    echo "  -v, --vuln-management       Enable Image Scanning with Sysdig Secure for Cloud. Use with -c/--cloud."
     echo
     echo
     echo "ENVIRONMENT VARIABLES:"
@@ -783,6 +783,11 @@ function setup () {
         select_region
     fi
 
+    if [ "$USE_AGENT" = true ]
+    then
+        deploy_agent
+    fi
+
     if [ "$USE_MONITOR_API" = true ]
     then
         configure_API "MONITOR" ${MONITOR_URL} ${MONITOR_API_ENDPOINT}
@@ -795,12 +800,13 @@ function setup () {
 
     if [ "$USE_AGENT" = true ]
     then
-        deploy_agent
         test_agent
     fi
 
     if [ "$USE_CLOUD" = true ]
     then
+        # we can't run `track_has_cloud_account` and `deploy_cloud_connector`
+        # before `configure_API` because they use data set within `configure_API`
         track_has_cloud_account
         deploy_cloud_connector
         test_cloud_connector

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -612,10 +612,9 @@ function clean_setup () {
 
     if [ -d $TRACK_DIR ]
     then
-        # rm -rf $TRACK_DIR/
-        # sed -i '/init.sh/d' /root/.profile  # removes the script from .profile so it is not executed in new challenges
-        # touch $WORK_DIR/user_data_OK # flag environment configured with user data
-        echo "CLEANUP-DEBUG: Remove nothing yet"
+        rm -rf $TRACK_DIR/
+        sed -i '/init.sh/d' /root/.profile  # removes the script from .profile so it is not executed in new challenges
+        touch $WORK_DIR/user_data_OK # flag environment configured with user data
     else
         panic_msg
     fi

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -563,8 +563,7 @@ function test_cloud_connector () {
             then 
                 LAST_SEEN_DATE=$(echo "$line" | cut -d' ' -f3) # extract date
                 LAST_SEEN_DATE_EPOCH=$(date --date "$LAST_SEEN_DATE" +%s)
-                echo "compare: ${LAST_SEEN_DATE_EPOCH} > ${CLOUD_CONNECTOR_DEPLOY_QUERY_EPOCH}"
-                echo "compare: ${LAST_SEEN_DATE} > ${CLOUD_CONNECTOR_DEPLOY_QUERY}"
+
                 if [[ "${LAST_SEEN_DATE_EPOCH}" > "${CLOUD_CONNECTOR_DEPLOY_QUERY_EPOCH}" ]]
                 then
                     echo "    Found cloud account: $line"
@@ -764,12 +763,6 @@ function setup () {
         select_region
     fi
 
-    if [ "$USE_AGENT" = true ]
-    then
-        deploy_agent
-        test_agent
-    fi
-
     if [ "$USE_MONITOR_API" = true ]
     then
         configure_API "MONITOR" ${MONITOR_URL} ${MONITOR_API_ENDPOINT}
@@ -778,6 +771,12 @@ function setup () {
     if [ "$USE_SECURE_API" = true ]
     then
         configure_API "SECURE" ${SECURE_URL} ${SECURE_API_ENDPOINT}
+    fi
+
+    if [ "$USE_AGENT" = true ]
+    then
+        deploy_agent
+        test_agent
     fi
 
     if [ "$USE_CLOUD" = true ]

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -576,7 +576,7 @@ function test_cloud_connector () {
             if [[ "${line}" =~ "${CLOUD_ACCOUNT_ID}" ]]
             then 
                 # the account_id matches
-                LAST_SEEN_DATE=$(echo "$line" | cut -d' ' -f3) # extract date
+                LAST_SEEN_DATE=$(echo "$line" | cut -d' ' -f4) # extract date
                 LAST_SEEN_DATE_EPOCH=$(date --date "$LAST_SEEN_DATE" +%s)
                 # is this account date_last_seen value greater than the deployment_date in this script?
                 # ^ this means, we want the cloud account to be active now

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -516,7 +516,7 @@ function track_has_cloud_account () {
 ##
 function deploy_cloud_connector () {
     CLOUD_CONNECTOR_DEPLOY_DATE=$(date -d '+2 hour' +"%F__%H_%M")
-    CLOUD_CONNECTOR_DEPLOY_QUERY=$(date +"%FT%H:%M:%S") # get deployment date that match format and timezone of the date returned by sysdig API CloudProvidersLastSeen
+    CLOUD_CONNECTOR_DEPLOY_QUERY=$(date +"%FT%H:%M:%S") # get a deployment date that matches the format and timezone of the date returned by sysdig API CloudProvidersLastSeen
     CLOUD_REGION=""
     echo ${CLOUD_CONNECTOR_DEPLOY_DATE} > $WORK_DIR/cloud_connector_deploy_date
     echo ${CLOUD_CONNECTOR_DEPLOY_QUERY} > $WORK_DIR/cloud_connector_deploy_query

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -576,7 +576,8 @@ function test_cloud_connector () {
             then 
                 # the account_id matches
                 LAST_SEEN_DATE=$(echo "$line" | cut -d' ' -f1) # extract date
-                LAST_SEEN_DATE_EPOCH=$(date --date "$LAST_SEEN_DATE" +%s)
+                [[ $LAST_SEEN_DATE == "null" ]] && LAST_SEEN_DATE_EPOCH=0 || LAST_SEEN_DATE_EPOCH=$(date --date "$LAST_SEEN_DATE" +%s)
+
                 # is this account date_last_seen value greater than the deployment_date in this script?
                 # ^ this means, we want the cloud account to be active now
                 # Instruqt reuses the accounts, so we don't want a false positive for reusing an account


### PR DESCRIPTION
## Context

### Support cloud-training

This PR includes some basic changes to deploy the cloud-connector in the three major cloud vendors using the terraform installer. These changes will support the automatic installation of the tool for future tracks based on Sysdig Cloud features.

### Support regions in cloud-envs

The Sysdig Monitor and Secure Dashboards (SDs) are available in multiple regions. There's not a unique URL and every one of them has different access URLs, endpoints, etc. Our Instruqt tracks include different types of tabs (Terminal, Services, WebPages). In order to include in our tracks an Instruqt tab with access to the SDs, we deploy nginx running in a host (important note: it is a VM, not a container. See below) with a redirect configuration, that points the tab to the right SDs region for every user (based on what they selected in the first challenge). 

The environment that Instruqt provides to access cloud accounts (AWS, Azure, GCP) provides the next assets:
- a cloud account
- a container running a client to provide an nginx web server exposing the account details.

And the next tabs:
- The Service tab points to the cloud-client webserver. It exposes the account data for the user, but no access to the Cloud Dashboard. Just the credentials.
- A Terminal tab configured with the cloud-CLI tool (for example, aws-cli) and configured with the set of permissions we define in the course. This is really handy, as the user does not need to authenticate or spend time configuring the CLI.

We want to implement a consistent experience across all of our different tracks, including the cloud ones. To do so, we need a tab with access to the SDs. 

### Support set up region-only

The proposed changes in this PR will also add support to set up region only with the `init.sh` script we use to set up our tracks. This is aimed for tracks where we explain how to install the agent or the cloud-connector, where we don't want to automate the steps. But we want to ease other stuff like having direct access from the tab to the right Sysdig Dashboard domain name based on user region.


## Problem statement

Our current tooling (`common/init.sh` and related scripts) runs normally in a host, where nginx runs as a service (managed with `systemctl`). This is not available in the container provided for cloud tracks. Of course, we can append to the sandbox a host, but we can use the provided container and webserver to keep it simple.

## Solution

Modify the current script to reuse the existing nginx server in the track cloud container to expose the redirect that makes the SDs available in the Instruqt tabs.

I tested this manually with a similar approach with the help of @pmusa (thx for the pair programming time together!) and it worked fine. We just need to implement this now following the same tooling that we have right now.

Signed-off-by: pablopez <pablo.lopezzaldivar@sysdig.com>