### PR TITLE
add: k8s audit logs enabled by default with helm install

### DIFF
--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -10,7 +10,6 @@
 
 trap '' 2 # Signal capture quit with Ctrl+C
 
-set -euxo pipefail
 
 ###########################    GLOBAL CONSTANTS    ############################
 F_BOLD='\e[1m'
@@ -21,7 +20,6 @@ F_CLEAR='\e[0m'
 WORK_DIR=/opt/sysdig
 TRACK_DIR=/root/prepare-track
 AGENT_CONF_DIR=/root/sysdig-agent
-INSTRUQT_USER_ID=${INSTRUQT_USER_ID}
 
 ##############################    GLOBAL VARS    ##############################
 INSTALL_WITH=''

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -10,6 +10,7 @@
 
 trap '' 2 # Signal capture quit with Ctrl+C
 
+set -euxo pipefail
 
 ###########################    GLOBAL CONSTANTS    ############################
 F_BOLD='\e[1m'

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -484,6 +484,7 @@ function test_agent () {
     attempt=0
     MAX_ATTEMPTS=10 # 0.5 minutes
     CONNECTED_MSG="Sending scraper version"
+    FOUND_COLLECTOR=""
     connected=false
 
     while [ -z ${FOUND_COLLECTOR} ] && [ "$connected" != true ] && [ $attempt -le $MAX_ATTEMPTS ]

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -36,7 +36,6 @@ USE_SECURE_API=false
 USE_NODE_ANALYZER=false
 USE_KSPM=false
 USE_PROMETHEUS=false
-USE_AUDIT_LOG=false
 USE_RAPID_RESPONSE=false
 USE_K8S=false
 USE_CLOUD=false
@@ -412,10 +411,6 @@ function intro () {
 
     if [ "$USE_PROMETHEUS" == true ]; then
       echo "    - Enable the Agent Prometheus collector."
-    fi
-
-    if [ "$USE_AUDIT_LOG" == true ]; then
-      echo "    - Enable K8s audit log support for Sysdig Secure."
     fi
 
     if [ "$USE_CLOUD" == true ]; then
@@ -833,9 +828,6 @@ function check_flags () {
             --rapid-response | -b)
                 export USE_RAPID_RESPONSE=true
                 ;;
-            --log | -l)
-                export USE_AUDIT_LOG=true
-                ;;  
             --vuln-management | -v)
                 export USE_CLOUD_SCAN_ENGINE=true
                 ;;

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -43,7 +43,7 @@ USE_RAPID_RESPONSE=false
 USE_K8S=false
 USE_CLOUD=false
 USE_CLOUD_SCAN_ENGINE=false
-USE_REGION_CLOUD=false
+USE_CLOUD_REGION=false
 USE_AGENT_REGION=false
 
 ##############################    GLOBAL VARS    ##############################

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -481,7 +481,7 @@ function test_agent () {
     fi
 
     attempt=0
-    MAX_ATTEMPTS=60 # 3 minutes
+    MAX_ATTEMPTS=10 # 0.5 minutes
     CONNECTED_MSG="Sending scraper version"
     connected=false
 

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -459,7 +459,7 @@ function deploy_agent () {
         read -p "  Insert your Sysdig Agent Key: " AGENT_ACCESS_KEY;
     fi
 
-    if [[ "$INSTALL_WITH" == "helm" ]]; # in helm, we deploy by default the AC for k8s audit loging, we need the api
+    if [[ -z "$INSTALL_WITH" ]] && [ `which helm` ]; # in helm, we deploy by default the AC for k8s audit loging, we need the api
     then
         configure_API "SECURE" ${SECURE_URL} ${SECURE_API_ENDPOINT}
     fi

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -341,7 +341,7 @@ function installation_method () {
 # Deploy a Sysdig Agent.
 #
 # Usage:
-#   install_agent ${CLUSTER_NAME} ${ACCESS_KEY} ${COLLECTOR} ${HELM_REGION_ID}
+#   install_agent ${CLUSTER_NAME} ${ACCESS_KEY} ${COLLECTOR} ${HELM_REGION_ID} ${SECURE_API_TOKEN}
 ##
 function install_agent () {
 
@@ -349,12 +349,13 @@ function install_agent () {
     ACCESS_KEY=$2
     COLLECTOR=$3
     HELM_REGION_ID=$4
+    SECURE_API_TOKEN=$5
 
     installation_method
 
     if [[ "$INSTALL_WITH" == "helm" ]]
     then
-        source $TRACK_DIR/install_with_helm.sh $CLUSTER_NAME $ACCESS_KEY $HELM_REGION_ID
+        source $TRACK_DIR/install_with_helm.sh $CLUSTER_NAME $ACCESS_KEY $HELM_REGION_ID $SECURE_API_TOKEN
     else
         source $TRACK_DIR/install_with_${INSTALL_WITH}.sh $CLUSTER_NAME $ACCESS_KEY $COLLECTOR
     fi
@@ -457,10 +458,15 @@ function deploy_agent () {
         read -p "  Insert your Sysdig Agent Key: " AGENT_ACCESS_KEY;
     fi
 
+    if [[ "$INSTALL_WITH" == "helm" ]]; # in helm, we deploy by default the AC for k8s audit loging, we need the api
+    then
+        configure_API "SECURE" ${SECURE_URL} ${SECURE_API_ENDPOINT}
+    fi
+
     echo -e "  The agent is being installed in the background.\n"
     ACCESSKEY=`echo ${AGENT_ACCESS_KEY} | tr -d '\r'`
 
-    install_agent ${AGENT_DEPLOY_DATE}_${RANDOM_CLUSTER_ID} ${AGENT_ACCESS_KEY} ${AGENT_COLLECTOR} ${HELM_REGION_ID}
+    install_agent ${AGENT_DEPLOY_DATE}_${RANDOM_CLUSTER_ID} ${AGENT_ACCESS_KEY} ${AGENT_COLLECTOR} ${HELM_REGION_ID} ${SYSDIG_SECURE_API_TOKEN}
 }
 
 ##

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -21,7 +21,7 @@ F_CLEAR='\e[0m'
 WORK_DIR=/opt/sysdig
 TRACK_DIR=/root/prepare-track
 AGENT_CONF_DIR=/root/sysdig-agent
-
+INSTRUQT_USER_ID=${INSTRUQT_USER_ID}
 
 ##############################    GLOBAL VARS    ##############################
 INSTALL_WITH=''

--- a/common/prepare-track/install_with_helm.sh
+++ b/common/prepare-track/install_with_helm.sh
@@ -8,8 +8,6 @@
 #
 ##
 
-set -euxo pipefail
-
 OUTPUT=/opt/sysdig/helm_install.out
 SOCKET_PATH=/run/k3s/containerd/containerd.sock
 CLUSTER_NAME=$1

--- a/common/prepare-track/install_with_helm.sh
+++ b/common/prepare-track/install_with_helm.sh
@@ -56,13 +56,6 @@ then
     HELM_OPTS="-f $AGENT_CONF_DIR/prometheus.yaml $HELM_OPTS"
 fi
 
-if [ "$USE_AUDIT_LOG" = true ]
-then
-    HELM_OPTS="--set agent.auditLog.enabled=true $HELM_OPTS"
-    HELM_OPTS="--set agent.auditLog.auditServerUrl=0.0.0.0 $HELM_OPTS"
-    HELM_OPTS="--set agent.auditLog.auditServerPort=7765 $HELM_OPTS"
-fi
-
 if [ "$USE_RAPID_RESPONSE" = true ]
 then
     HELM_OPTS="--set rapidResponse.enabled=true \

--- a/common/prepare-track/install_with_helm.sh
+++ b/common/prepare-track/install_with_helm.sh
@@ -3,7 +3,7 @@
 # Deploy a Sysdig Agent using Helm.
 #
 # Usage:
-#   install_with_helm.sh ${CLUSTER_NAME} ${ACCESS_KEY} ${HELM_REGION_ID}
+#   install_with_helm.sh ${CLUSTER_NAME} ${ACCESS_KEY} ${HELM_REGION_ID} ${SECURE_API_TOKEN}
 #   (check ./init.sh to learn more about possible HELM_REGION_ID values )
 #
 ##
@@ -13,9 +13,16 @@ SOCKET_PATH=/run/k3s/containerd/containerd.sock
 CLUSTER_NAME=$1
 ACCESS_KEY=$2
 HELM_REGION_ID=$3
+SECURE_API_TOKEN=$4
 
 helm repo add sysdig https://charts.sysdig.com >> ${OUTPUT} 2>&1
 helm repo update >> ${OUTPUT} 2>&1
+
+# ingest k8sAuditDetections via admission controller by default (with AC scanning disabled)
+HELM_OPTS="--set admissionController.enabled=true \
+	--set admissionController.features.k8sAuditDetections=true \
+	--set admissionController.scanner.enabled=false \
+	--set admissionController.sysdig.secureAPIToken=${SECURE_API_TOKEN}"
 
 if [ "$USE_NODE_ANALYZER" = true ]
 then

--- a/common/prepare-track/install_with_helm.sh
+++ b/common/prepare-track/install_with_helm.sh
@@ -14,6 +14,7 @@ CLUSTER_NAME=$1
 ACCESS_KEY=$2
 HELM_REGION_ID=$3
 SECURE_API_TOKEN=$4
+HELM_OPTS=""
 
 helm repo add sysdig https://charts.sysdig.com >> ${OUTPUT} 2>&1
 helm repo update >> ${OUTPUT} 2>&1
@@ -22,7 +23,7 @@ helm repo update >> ${OUTPUT} 2>&1
 HELM_OPTS="--set admissionController.enabled=true \
 	--set admissionController.features.k8sAuditDetections=true \
 	--set admissionController.scanner.enabled=false \
-	--set admissionController.sysdig.secureAPIToken=${SECURE_API_TOKEN}"
+	--set admissionController.sysdig.secureAPIToken=${SECURE_API_TOKEN} ${HELM_OPTS}"
 
 if [ "$USE_NODE_ANALYZER" = true ]
 then

--- a/common/prepare-track/install_with_helm.sh
+++ b/common/prepare-track/install_with_helm.sh
@@ -8,6 +8,8 @@
 #
 ##
 
+set -euxo pipefail
+
 OUTPUT=/opt/sysdig/helm_install.out
 SOCKET_PATH=/run/k3s/containerd/containerd.sock
 CLUSTER_NAME=$1


### PR DESCRIPTION
This PR adds by default the deployment of the Sysdig AC for k8s with:
- scanner disabled
- ingestion of k8s API events enabled.


It have been tested in the track `ilt-series-cdr` with options:

```
/usr/bin/bash /root/prepare-track/init.sh --agent --rapid-response --secure  --provision-user --skip-cleanup

/usr/bin/bash /root/prepare-track/init.sh --agent --rapid-response --secure --skip-cleanup
```
