### PR TITLE
[instruqt] add Secure for Cloud new agentless onboarding CIEM, CDR, CSPM

### DIFF
--- a/common/prepare-track/cloud/install_with_terraform.sh
+++ b/common/prepare-track/cloud/install_with_terraform.sh
@@ -26,7 +26,7 @@ if [ "$PROVIDER" == "aws" ]
 then
     cd aws
 
-    bucket_name="audit-$(echo $RANDOM_ID | sed 's/_/-/g'))"
+    bucket_name="audit-$(echo $RANDOM_ID | sed 's/_/-/g')"
     trail_name="trail-$bucket_name"
 
     # Create an S3 bucket

--- a/common/prepare-track/cloud/install_with_terraform.sh
+++ b/common/prepare-track/cloud/install_with_terraform.sh
@@ -6,6 +6,8 @@
 #   install_with_terraform.sh $PROVIDER $SYSDIG_SECURE_API_TOKEN $SECURE_API_ENDPOINT $CLOUD_REGION $CLOUD_ACCOUNT_ID
 ##
 
+apt update && apt install -y less
+
 # logs
 OUTPUT=/opt/sysdig/cloud/terraform_install.out
 mkdir -p /opt/sysdig/cloud/
@@ -16,22 +18,142 @@ SYSDIG_SECURE_API_TOKEN=$2
 SECURE_API_ENDPOINT=$3
 CLOUD_REGION=$4
 CLOUD_ACCOUNT_ID=$5
+RANDOM_ID=$(cat /opt/sysdig/random_string_OK)
 
 cd /root/prepare-track/cloud
 
 if [ "$PROVIDER" == "aws" ]
 then
     cd aws
+
+    bucket_name="audit-$RANDOM_ID)"
+    trail_name="trail-$bucket_name"
+
+    # Create an S3 bucket
+    aws s3api create-bucket --bucket "$bucket_name" --region us-east-1 | jq '.'
+
+    # Generate a bucket policy JSON file
+    cat <<EOF > bucket-policy.json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AWSCloudTrailAclCheck20150319",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "cloudtrail.amazonaws.com"
+            },
+            "Action": "s3:GetBucketAcl",
+            "Resource": "arn:aws:s3:::$bucket_name"
+        },
+        {
+            "Sid": "AWSCloudTrailWrite20150319",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "cloudtrail.amazonaws.com"
+            },
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::$bucket_name/AWSLogs/${CLOUD_ACCOUNT_ID}/*",
+            "Condition": {
+                "StringEquals": {
+                    "s3:x-amz-acl": "bucket-owner-full-control"
+                }
+            }
+        }
+    ]
+}
+EOF
+
+    # Apply the bucket policy
+    aws s3api put-bucket-policy --bucket "$bucket_name" --policy file://bucket-policy.json  | jq '.'
+
+    # Create a CloudTrail trail
+    aws cloudtrail create-trail --name "$trail_name" --s3-bucket-name "$bucket_name"  | jq '.'
+
+    # Start the trail
+    aws cloudtrail start-logging --name "$trail_name" | jq '.'
+
+    API_ENDPOINT="/api/secure/onboarding/v3/environments/AWS/installActions/Terraform"
+    FEATURES=""
+    # FEATURES=${FEATURES}"&feature=FEATURE_SECURE_IDENTITY_ENTITLEMENT"
+    FEATURES=${FEATURES}"&feature=FEATURE_SECURE_THREAT_DETECTION"
+    FEATURES=${FEATURES}"&feature=FEATURE_SECURE_CONFIG_POSTURE"
+    PARAMETERS="?accountType=single&region=us-east-1"
+    PARAMETERS=${PARAMETERS}${FEATURES}
+
+    curl -s -k -X GET \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer ${SYSDIG_SECURE_API_TOKEN}" \
+        "${SECURE_API_ENDPOINT}${API_ENDPOINT}${PARAMETERS}" > api_response.json
+
+    rm cloud-connector-aws.tf
+
+    cat api_response.json | jq -r .installAction > main.tf
+    ROLE_NAME=$(cat api_response.json | jq -r .values.roleName)
+
+
+    terraform init && terraform apply -auto-approve
+
     echo "  Initializing Terraform modules, backend and provider plugins" \
     && terraform init >> ${OUTPUT} 2>&1 \
     && echo "    Terraform has been successfully initialized. Applying... (this will take a few minutes)" \
     && terraform apply -auto-approve \
-        -var="training_secure_api_token=$SYSDIG_SECURE_API_TOKEN" \
-        -var="training_secure_url=$SECURE_API_ENDPOINT" \
-        -var="training_aws_region=$CLOUD_REGION" \
-        -var="deploy_scanner=$USE_CLOUD_SCAN_ENGINE" \
         >> ${OUTPUT} 2>&1 \
     && echo "    Terraform apply completed! Check all TF deployment logs at: $OUTPUT"
+
+    # onboard AWS account
+    ACCOUNT_ID_INTERNAL=$(curl -s -k -X POST \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer ${SYSDIG_SECURE_API_TOKEN}" \
+        --data '{
+            "enabled": true,
+            "provider": "PROVIDER_AWS",
+            "providerId": "'${AWS_ACCOUNT_ID}'"
+        }' \
+        "${SECURE_API_ENDPOINT}/api/cloudauth/v1/accounts" | jq -r '.id')
+
+    # enable components
+    cat api_response.json | jq -c '.accountConfig.components[]' | while read -r data; 
+        do
+            echo "Adding component: $data"
+            echo ""
+            curl -s -k -X POST \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer ${SYSDIG_SECURE_API_TOKEN}" \
+                --data "$data" \
+                "${SECURE_API_ENDPOINT}/api/cloudauth/v1/accounts/${ACCOUNT_ID_INTERNAL}/components"
+            echo ""
+        done
+
+    # add features
+    cat api_response.json | jq -c '.accountConfig.features[]' | while read -r data;
+        do
+            FEATURE=$(echo $data | jq -r .type)
+            echo "Adding feature: ${FEATURE}"
+            curl -s -k -X PUT \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer ${SYSDIG_SECURE_API_TOKEN}" \
+                --data "$data" \
+                "${SECURE_API_ENDPOINT}/api/cloudauth/v1/accounts/${ACCOUNT_ID_INTERNAL}/feature/${FEATURE}"
+            echo ""
+        done
+
+    # enable CIEM
+
+    curl -s -k -X PUT \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer ${SYSDIG_SECURE_API_TOKEN}" \
+        --data '{
+        "accountId": "'${AWS_ACCOUNT_ID}'",
+        "provider": "aws",
+        "alias": "'${RANDOM_ID}'",
+        "roleAvailable": true,
+        "roleName": "'${ROLE_NAME}'",
+        "ciemEnabled": true
+        }' \
+        ${SECURE_API_ENDPOINT}/api/cloud/v2/accounts/${AWS_ACCOUNT_ID} \
+        | jq
+
 fi
 
 if [ "$PROVIDER" == "gcp" ]

--- a/common/prepare-track/cloud/install_with_terraform.sh
+++ b/common/prepare-track/cloud/install_with_terraform.sh
@@ -26,7 +26,7 @@ if [ "$PROVIDER" == "aws" ]
 then
     cd aws
 
-    bucket_name="audit-$RANDOM_ID)"
+    bucket_name="audit-$(echo $RANDOM_ID | sed 's/_/-/g'))"
     trail_name="trail-$bucket_name"
 
     # Create an S3 bucket

--- a/common/prepare-track/cloud/install_with_terraform.sh
+++ b/common/prepare-track/cloud/install_with_terraform.sh
@@ -134,7 +134,6 @@ EOF
         done
 
     # enable CIEM
-
     curl -s -k -X PUT \
         -H "Content-Type: application/json" \
         -H "Authorization: Bearer ${SYSDIG_SECURE_API_TOKEN}" \
@@ -148,6 +147,22 @@ EOF
         }' \
         ${SECURE_API_ENDPOINT}/api/cloud/v2/accounts/${AWS_ACCOUNT_ID} \
         | jq >> ${OUTPUT} 2>&1
+
+    # retrigger CSPM + CIEM scan just in case it does not trigger automatically after scan
+    # no wait for finish
+    curl $PRODUCT_API_ENDPOINT/api/cspm/v1/tasks \
+        --header "Authorization: Bearer $API_TOKEN" \
+        --header 'Content-Type: application/json' \
+        --data-raw '{
+            "task": {
+                "name": "AWS Scan - Instruqt setup",
+                "type": 7,
+                "parameters": {
+                    "account": "'${AWS_ACCOUNT_ID}'",
+                    "providerType": "AWS"
+                }
+            }
+        }' -s
 
 fi
 

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -48,6 +48,7 @@ USE_CLOUD_REGION=false
 USE_AGENT_REGION=false
 USE_RUNTIME_VM=false
 USE_CURSES=false
+USE_NO_CHECK=false
 
 ##############################    GLOBAL VARS    ##############################
 TEST_AGENT_ACCESS_KEY=ZTRlNDFiMGUtYTg5Yi00YWU4LWJlZjYtMzA4Y2FmZDIwMjAx
@@ -846,6 +847,7 @@ function help () {
     echo "  -8, --kube-adm              Customize installer for kubeadm k8s cluster"
     echo "  --on-prem <on_prem_endpoint>       In case an on-prem backend is used, set here the endpoint value."                     
     echo "      --runtime-vm            Enable VM Runtime Scanner. Use with --node-analyzer."
+    echo "      --no-check              Remove agent and cloud connector post install health check."
     echo
     echo
     echo "ENVIRONMENT VARIABLES:"
@@ -931,6 +933,9 @@ function check_flags () {
             --runtime-vm)
                 export USE_RUNTIME_VM=true
                 ;;
+            --no-check)
+                export USE_NO_CHECK=true
+                ;;                
             --help | -h)
                 help
                 exit 0
@@ -1017,7 +1022,10 @@ function setup () {
 
     if [ "$USE_AGENT" = true ]
     then
-        test_agent
+        if [ "$USE_NO_CHECK" = false ]
+        then
+            test_agent
+        fi
     fi
 
     if [ "$USE_CLOUD" = true ]
@@ -1026,7 +1034,10 @@ function setup () {
         # before `configure_API` because they use data set within `configure_API`
         track_has_cloud_account
         deploy_cloud_connector
-        test_cloud_connector
+        if [ "$USE_NO_CHECK" = false ]
+        then
+            test_cloud_connector
+        fi
     fi
     
     if [ "$SKIP_CLEANUP" = false ]

--- a/common/prepare-track/install_with_helm.sh
+++ b/common/prepare-track/install_with_helm.sh
@@ -18,6 +18,10 @@ COLLECTOR=$5
 # HELM_OPTS=""
 
 HELM_OPTS="--set agent.sysdig.settings.falcobaseline.report_interval=150000000000 \
+--set agent.sysdig.settings.falcobaseline.max_drops_buffer_rate_percentage=0.99 \
+--set agent.sysdig.settings.falcobaseline.max_sampling_ratio=128 \
+--set agent.sysdig.settings.falcobaseline.debug_metadata=true \
+--set agent.sysdig.settings.falcobaseline.debug=true \
 --set agent.sysdig.settings.falcobaseline.randomize_start=false "
 
 
@@ -123,7 +127,7 @@ custom_hostnaming
 
 # echo "Deploying Sysdig Agent with Helm"
 kubectl create ns sysdig-agent >> ${OUTPUT} 2>&1
-helm upgrade --install sysdig-agent --namespace sysdig-agent \
+(set -x; helm upgrade --install sysdig-agent --namespace sysdig-agent \
     --set global.clusterConfig.name="${CLUSTER_NAME}" \
     --set global.sysdig.accessKey=${ACCESS_KEY} \
     --set global.sysdig.region=${HELM_REGION_ID} \
@@ -137,4 +141,4 @@ helm upgrade --install sysdig-agent --namespace sysdig-agent \
     --set agent.collectorSettings.collectorHost=${COLLECTOR} \
     -f ${AGENT_CONF_DIR}/values.yaml \
     ${HELM_OPTS} \
-sysdig/sysdig-deploy >> ${OUTPUT} 2>&1 &
+sysdig/sysdig-deploy >> ${OUTPUT} 2>&1 &)

--- a/common/prepare-track/install_with_helm.sh
+++ b/common/prepare-track/install_with_helm.sh
@@ -15,7 +15,13 @@ ACCESS_KEY=$2
 HELM_REGION_ID=$3
 SECURE_API_TOKEN=$4
 COLLECTOR=$5
-# HELM_OPTS="" Commenting this out to allow exporting extra opts outside of this script with `export HELM_OPTS=--set setting.param=value --set foo2=value`
+HELM_OPTS=""
+
+HELM_OPTS='
+--set agent.sysdig.settings.falcobaseline.report_interval=150000000000 \
+--set agent.sysdig.settings.falcobaseline.randomize_start=false \
+--set agent.sysdig.settings.falcobaseline.location: "/tmp/fingerprints"'
+
 
 # new hostnames, to avoid duplicated names as much as possible
 function custom_hostnaming () {
@@ -65,7 +71,11 @@ then
     HELM_OPTS="--set nodeAnalyzer.nodeAnalyzer.deploy=true \
     --set nodeAnalyzer.secure.vulnerabilityManagement.newEngineOnly=true \
     --set nodeAnalyzer.nodeAnalyzer.sslVerifyCertificate=false \
-    --set nodeAnalyzer.nodeAnalyzer.runtimeScanner.deploy=true $HELM_OPTS"
+    --set nodeAnalyzer.nodeAnalyzer.benchmarkRunner.deploy=false \
+    --set nodeAnalyzer.nodeAnalyzer.runtimeScanner.deploy=true \
+    --set nodeAnalyzer.nodeAnalyzer.runtimeScanner.env.DEV_STARTUP_DELAY_DURATION_JITTER_DURATION=15s \
+    --set nodeAnalyzer.nodeAnalyzer.runtimeScanner.falcobaseline.randomize_start=false \
+    --set nodeAnalyzer.nodeAnalyzer.runtimeScanner.falcobaseline.report_interval=300000000000 $HELM_OPTS"
 
     if [ "$USE_RUNTIME_VM" = true ]
     then

--- a/common/prepare-track/install_with_helm.sh
+++ b/common/prepare-track/install_with_helm.sh
@@ -15,14 +15,14 @@ ACCESS_KEY=$2
 HELM_REGION_ID=$3
 SECURE_API_TOKEN=$4
 COLLECTOR=$5
-# HELM_OPTS=""
+HELM_OPTS="${HELM_OPTS}"
 
 HELM_OPTS="--set agent.sysdig.settings.falcobaseline.report_interval=150000000000 \
 --set agent.sysdig.settings.falcobaseline.max_drops_buffer_rate_percentage=0.99 \
 --set agent.sysdig.settings.falcobaseline.max_sampling_ratio=128 \
 --set agent.sysdig.settings.falcobaseline.debug_metadata=true \
 --set agent.sysdig.settings.falcobaseline.debug=true \
---set agent.sysdig.settings.falcobaseline.randomize_start=false "
+--set agent.sysdig.settings.falcobaseline.randomize_start=false $HELM_OPTS"
 
 
 # new hostnames, to avoid duplicated names as much as possible

--- a/common/prepare-track/install_with_helm.sh
+++ b/common/prepare-track/install_with_helm.sh
@@ -15,7 +15,7 @@ ACCESS_KEY=$2
 HELM_REGION_ID=$3
 SECURE_API_TOKEN=$4
 COLLECTOR=$5
-HELM_OPTS=""
+# HELM_OPTS="" Commenting this out to allow exporting extra opts outside of this script with `export HELM_OPTS=--set setting.param=value --set foo2=value`
 
 # new hostnames, to avoid duplicated names as much as possible
 function custom_hostnaming () {

--- a/common/prepare-track/install_with_helm.sh
+++ b/common/prepare-track/install_with_helm.sh
@@ -15,12 +15,10 @@ ACCESS_KEY=$2
 HELM_REGION_ID=$3
 SECURE_API_TOKEN=$4
 COLLECTOR=$5
-HELM_OPTS=""
+# HELM_OPTS=""
 
-HELM_OPTS='
---set agent.sysdig.settings.falcobaseline.report_interval=150000000000 \
---set agent.sysdig.settings.falcobaseline.randomize_start=false \
---set agent.sysdig.settings.falcobaseline.location: "/tmp/fingerprints"'
+HELM_OPTS="--set agent.sysdig.settings.falcobaseline.report_interval=150000000000 \
+--set agent.sysdig.settings.falcobaseline.randomize_start=false "
 
 
 # new hostnames, to avoid duplicated names as much as possible


### PR DESCRIPTION
- Update the onboarding method for AWS accounts, following the recommended steps to enable:
  - [agentless CIEM for AWS](https://docs.google.com/document/d/1_5agd7GsCEkP04wN6SXcjv2IMN7d4G1bvy6w5RiFByU/edit)
  - CDR/CSPM: use sequence of API calls in the UI to onboard a new accounts with TF
- Remove HELM_OPS wipe to allow loading extra values from specific labs
- Add init.sh option to skip agent and cloud connector checks (by default tests are executed)
- Add agent settings to get VM In Use information sooner.
- Print helm upgrade sysdig/sysdig-deploy command in the instruqt track logs
