### PR TITLE
Fix user provisioning (v2)

### DIFF
--- a/common/prepare-track/account-provisioner-user-create.sh
+++ b/common/prepare-track/account-provisioner-user-create.sh
@@ -2,19 +2,11 @@
 ##
 # User provisioner, creates a user in a general training Sysdig account
 # so the user does not have to use its own.
-#
-# NOTE:
-# we reuse the existing test data inside of the init.sh script, add here the new credentials
-# also, we guarantee that for runs where both conditions (is_test_run AND user_provisioner) are meet
-# we test it with the user provisioned data
-# check f() overwrite_test_creds in init.sh for more info
-# TODO: merge both approaches, from a functional lab perspective, both are the same
 ##
 
 set -euxo pipefail
 
-if [ $# -ne 6 ]
-  then
+if [ $# -ne 6 ]; then
     echo "$0: Provide 6 arguments: "
     echo "$0: Defaulting to training account."
 
@@ -39,26 +31,30 @@ fi
 
 WORK_DIR=/opt/sysdig
 TRACK_DIR=/tmp/instruqt-assets/common/prepare-track
-mkdir -p $WORK_DIR
-mkdir -p $TRACK_DIR
+mkdir -p "$WORK_DIR"
+mkdir -p "$TRACK_DIR"
+
+# API Base URL for Platform (removing potential 'app' prefix)
+PLATFORM_API_URL=$(echo "${ACCOUNT_PROVISIONER_MONITOR_API_URL}" | sed 's/app\./api./')
 
 # Decode the base64 credentials
-ACCOUNT_PROVISIONER_MONITOR_API_TOKEN=$(echo -n ${ACCOUNT_PROVISIONER_MONITOR_API_TOKEN} | base64 --decode)
-ACCOUNT_PROVISIONER_SECURE_API_TOKEN=$(echo -n ${ACCOUNT_PROVISIONER_SECURE_API_TOKEN} | base64 --decode)
-ACCOUNT_PROVISIONER_AGENT_ACCESS_KEY=$(echo -n ${ACCOUNT_PROVISIONER_AGENT_ACCESS_KEY} | base64 --decode)
+ACCOUNT_PROVISIONER_MONITOR_API_TOKEN=$(echo -n "${ACCOUNT_PROVISIONER_MONITOR_API_TOKEN}" | base64 --decode)
+ACCOUNT_PROVISIONER_SECURE_API_TOKEN=$(echo -n "${ACCOUNT_PROVISIONER_SECURE_API_TOKEN}" | base64 --decode)
+ACCOUNT_PROVISIONER_AGENT_ACCESS_KEY=$(echo -n "${ACCOUNT_PROVISIONER_AGENT_ACCESS_KEY}" | base64 --decode)
 
 # persist values
-echo "${ACCOUNT_PROVISIONER_MONITOR_API_TOKEN}" > $WORK_DIR/ACCOUNT_PROVISIONER_MONITOR_API_TOKEN
-echo "${ACCOUNT_PROVISIONER_MONITOR_API_URL}" > $WORK_DIR/ACCOUNT_PROVISIONER_MONITOR_API_URL
-echo "${ACCOUNT_PROVISIONER_SECURE_API_TOKEN}" > $WORK_DIR/ACCOUNT_PROVISIONER_SECURE_API_TOKEN
-echo "${ACCOUNT_PROVISIONER_SECURE_API_URL}" > $WORK_DIR/ACCOUNT_PROVISIONER_SECURE_API_URL
-echo "${ACCOUNT_PROVISIONER_AGENT_ACCESS_KEY}" > $WORK_DIR/ACCOUNT_PROVISIONER_AGENT_ACCESS_KEY
-echo "${ACCOUNT_PROVISIONER_REGION_NUMBER}" > $WORK_DIR/ACCOUNT_PROVISIONER_REGION # check region ids in init.sh
+echo "${ACCOUNT_PROVISIONER_MONITOR_API_TOKEN}" > "$WORK_DIR/ACCOUNT_PROVISIONER_MONITOR_API_TOKEN"
+echo "${ACCOUNT_PROVISIONER_MONITOR_API_URL}" > "$WORK_DIR/ACCOUNT_PROVISIONER_MONITOR_API_URL"
+echo "${ACCOUNT_PROVISIONER_SECURE_API_TOKEN}" > "$WORK_DIR/ACCOUNT_PROVISIONER_SECURE_API_TOKEN"
+echo "${ACCOUNT_PROVISIONER_SECURE_API_URL}" > "$WORK_DIR/ACCOUNT_PROVISIONER_SECURE_API_URL"
+echo "${ACCOUNT_PROVISIONER_AGENT_ACCESS_KEY}" > "$WORK_DIR/ACCOUNT_PROVISIONER_AGENT_ACCESS_KEY"
+echo "${ACCOUNT_PROVISIONER_REGION_NUMBER}" > "$WORK_DIR/ACCOUNT_PROVISIONER_REGION"
 
-source $TRACK_DIR/lab_random_string_id.sh
+source "$TRACK_DIR/lab_random_string_id.sh"
 
 function provsion_user(){
-  # create user in parent account
+  # We use the old provisioning API because it returns the user API TOKEN,
+  # which is required by init.sh to configure the student environment.
   curl -s -k -X POST \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $1" \
@@ -69,21 +65,19 @@ function provsion_user(){
   "lastName": "'"${SPA_USER}"'",
   "systemRole": "ROLE_USER"
   }' \
-  "${ACCOUNT_PROVISIONER_SECURE_API_URL}"/api/user/provisioning/ \
-  | jq > $WORK_DIR/account.json
+  "${ACCOUNT_PROVISIONER_SECURE_API_URL}/api/user/provisioning/" \
+  | jq > "$WORK_DIR/account.json"
 }
 
-# define new user creds, and feed it to instruqt lab as an agent var
-WORK_DIR=/opt/sysdig
+# define new user creds
 SPA_PASS=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 16 ; echo '')
-echo "${SPA_PASS}"
-echo "${SPA_PASS}" > $WORK_DIR/ACCOUNT_PROVISIONED_PASS
+echo "${SPA_PASS}" > "$WORK_DIR/ACCOUNT_PROVISIONED_PASS"
 agent variable set SPA_PASS "${SPA_PASS}"
-# we use the same two random dictionary words to set user_name and cluster_name 
-SPA_USER=$(cat $WORK_DIR/ACCOUNT_PROVISIONED_USER)
-echo "${SPA_USER}"
+
+SPA_USER=$(cat "$WORK_DIR/ACCOUNT_PROVISIONED_USER")
 agent variable set SPA_USER "${SPA_USER}"
-if [ $DYNAMIC_PROVISIONER_MONITOR_ONLY == "true" ]; then
+
+if [ "$DYNAMIC_PROVISIONER_MONITOR_ONLY" == "true" ]; then
   agent variable set SPA_MONITOR_API_TOKEN "${ACCOUNT_PROVISIONER_MONITOR_API_TOKEN}"
   agent variable set SPA_MONITOR_API_URL "${ACCOUNT_PROVISIONER_MONITOR_API_URL}"
 else
@@ -92,168 +86,79 @@ else
   agent variable set SPA_SECURE_API_URL "${ACCOUNT_PROVISIONER_SECURE_API_URL}"
   agent variable set SPA_MONITOR_API_URL "${ACCOUNT_PROVISIONER_MONITOR_API_URL}"
 fi
-PROVISIONED_RANDOM_ID=$(cat $WORK_DIR/random_string_OK)
+
+PROVISIONED_RANDOM_ID=$(cat "$WORK_DIR/random_string_OK")
 agent variable set PROVISIONED_RANDOM_ID "${PROVISIONED_RANDOM_ID}"
 
-# Make PROVISIONED_RANDOM_ID available to all future login shells
+# Profile persistence
 if [ -n "${PROVISIONED_RANDOM_ID:-}" ]; then
-  # Export for the current shell (just in case)
   export PROVISIONED_RANDOM_ID
-
-  # Persist it for all future login shells
   cat <<EOF >/etc/profile.d/provisioned_random_id.sh
 export PROVISIONED_RANDOM_ID=$(printf '%q\n' "${PROVISIONED_RANDOM_ID}")
 EOF
 fi
 
-# create user in parent account
-if [ $DYNAMIC_PROVISIONER_MONITOR_ONLY == "true" ]; then
-    echo "Monitor provisioning only"
+# Provision User
+if [ "$DYNAMIC_PROVISIONER_MONITOR_ONLY" == "true" ]; then
     provsion_user "${ACCOUNT_PROVISIONER_MONITOR_API_TOKEN}"
 else
-    echo "Secure and Monitor provisioning"
     provsion_user "${ACCOUNT_PROVISIONER_SECURE_API_TOKEN}"
 fi
 
-# set flag user provisioned, all OK
-touch $WORK_DIR/user_provisioned_COMPLETED
+touch "$WORK_DIR/user_provisioned_COMPLETED"
 
-# disable onboarding, just in case someone enables it
-# this is not working today, always return "onboardingEnabled":true (reported)
-# curl -s -k -X POST \
-# -H "Content-Type: application/json" \
-# -H "Authorization: Bearer ${ACCOUNT_PROVISIONER_SECURE_API_TOKEN}" \
-# --data-binary '{
-#     "onboardingEnabled":false,
-#     "newOnboardingWizard":false,
-#     "falcoCloudEnabled":false,
-#     "falcoCloudBetaFlows":false,
-#     "onboardingSkipped":false,
-#     "oktaEnabled":false}' \
-# ${ACCOUNT_PROVISIONER_SECURE_API_URL}/api/secure/onboarding/v2/feature/status \
-# | jq > /dev/null
+# Get user info
+# Note: The old provisioning API returns { "user": { "id": ... }, "token": { "key": ... } }
+SPA_USER_ID=$(jq '.user.id' "$WORK_DIR/account.json")
+SPA_USER_API_TOKEN=$(jq -r '.token.key' "$WORK_DIR/account.json")
 
-# get user id and API token
-SPA_USER_ID=$(cat  $WORK_DIR/account.json | jq .user.id)
-SPA_USER_API_TOKEN=$(cat  $WORK_DIR/account.json | jq -r  .token.key)
-
-# disable onboarding for this particular user
+# Disable onboarding questionnaire
 curl -s -k -X POST \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer ${SPA_USER_API_TOKEN}" \
 --data-binary @- \
-"${ACCOUNT_PROVISIONER_SECURE_API_URL}"/api/secure/onboarding/v2/userProfile/questionnaire <<EOF > /dev/null
+"${ACCOUNT_PROVISIONER_SECURE_API_URL}/api/secure/onboarding/v2/userProfile/questionnaire" <<EOF > /dev/null
 [
-  {
-    "id": "additionalEnvironments",
-    "displayQuestion": "What are all the environments your company has?",
-    "choices": []
-  },
-  {
-    "id": "iacManifests",
-    "displayQuestion": "Where do you store your Infrastructure as Code manifests?",
-    "choices": []
-  },
-  {
-    "id": "cicdTool",
-    "displayQuestion": "What are your CI/CD tools?",
-    "choices": []
-  },
-  {
-    "id": "notificationChannels",
-    "displayQuestion": "How do you want to be notified outside of Sysdig?",
-    "choices": []
-  }
+  {"id": "additionalEnvironments", "displayQuestion": "Q", "choices": []},
+  {"id": "iacManifests", "displayQuestion": "Q", "choices": []},
+  {"id": "cicdTool", "displayQuestion": "Q", "choices": []},
+  {"id": "notificationChannels", "displayQuestion": "Q", "choices": []}
 ]
 EOF
 
-# get monitor operations team info
-if [ $DYNAMIC_PROVISIONER_SECURE_ONLY != "true" ]; then
-  # Get monitor operations team ID
+# Team assignment (Monitor)
+if [ "$DYNAMIC_PROVISIONER_SECURE_ONLY" != "true" ]; then
+  # 1. Find Monitor Operations Team ID
   MONITOR_OPS_TEAM_ID=$(curl -s -k -X GET \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer ${ACCOUNT_PROVISIONER_MONITOR_API_TOKEN}" \
-  "${ACCOUNT_PROVISIONER_MONITOR_API_URL}/api/v3/teams?filter=product:SDC&offset=0&orderBy=name:asc" | jq -r '.data[] | select(.name == "Monitor Operations") | .id')
-  if [ -z "$MONITOR_OPS_TEAM_ID" ]; then
+    -H "Authorization: Bearer ${ACCOUNT_PROVISIONER_MONITOR_API_TOKEN}" \
+    "${PLATFORM_API_URL}/platform/v1/teams?filter=product:monitor&offset=0&orderBy=name:asc" \
+    | jq -r '.data[] | select(.name == "Monitor Operations") | .id')
+
+  if [ -z "$MONITOR_OPS_TEAM_ID" ] || [ "$MONITOR_OPS_TEAM_ID" == "null" ]; then
       echo "Monitor Operations team not found"
       exit 1
   fi
-  # Get the account ID
-  echo "Monitor Operations team ID: $MONITOR_OPS_TEAM_ID"
 
-  curl -s -k -X GET \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer ${ACCOUNT_PROVISIONER_MONITOR_API_TOKEN}" \
-  "${ACCOUNT_PROVISIONER_MONITOR_API_URL}"/api/teams/${MONITOR_OPS_TEAM_ID} \
-  | jq > $WORK_DIR/monitor-operations-team.json
+  # 2. Find "Advanced with Sage Access" Role ID
+  SAGE_ROLE_ID=$(curl -s -k -X GET \
+    -H "Authorization: Bearer ${ACCOUNT_PROVISIONER_MONITOR_API_TOKEN}" \
+    "${PLATFORM_API_URL}/platform/v1/roles" \
+    | jq -r '.data[] | select(.name == "Advanced with Sage Access") | .id')
 
-  # edits
-  #   remove team, get all other info
-  jq '.team' "$WORK_DIR/monitor-operations-team.json" > "$WORK_DIR/monitor-operations-team.json.tmp"
-  cp "$WORK_DIR/monitor-operations-team.json.tmp" "$WORK_DIR/monitor-operations-team.json"
-  rm "$WORK_DIR/monitor-operations-team.json.tmp"
+  # 3. Determine assignment payload
+  if [ -n "$SAGE_ROLE_ID" ] && [ "$SAGE_ROLE_ID" != "null" ]; then
+      ROLE_PAYLOAD='{"customTeamRoleId": '$SAGE_ROLE_ID'}'
+      echo "Using custom role ID: $SAGE_ROLE_ID"
+  else
+      ROLE_PAYLOAD='{"standardTeamRole": "ROLE_TEAM_EDIT"}'
+      echo "Custom role not found, using fallback: ROLE_TEAM_EDIT"
+  fi
 
-  #   update version
-  # jq '.version += 1' "$WORK_DIR/monitor-operations-team.json" > "$WORK_DIR/monitor-operations-team.json.tmp"
-  # cp "$WORK_DIR/monitor-operations-team.json.tmp" "$WORK_DIR/monitor-operations-team.json"
-  # rm "$WORK_DIR/monitor-operations-team.json.tmp"
-
-  # remove all users that are role ROLE_TEAM_MANAGER
-  jq '.userRoles[] |= del(. | select(.role == "ROLE_TEAM_MANAGER"))' "$WORK_DIR/monitor-operations-team.json" > "$WORK_DIR/monitor-operations-team.json.tmp"
-  cp "$WORK_DIR/monitor-operations-team.json.tmp" "$WORK_DIR/monitor-operations-team.json"
-  rm "$WORK_DIR/monitor-operations-team.json.tmp"
-
-  # clean nulls in .userRoles[]
-  # del(.[][] | nulls)
-  jq '.userRoles |= del(.[] | nulls)' "$WORK_DIR/monitor-operations-team.json" > "$WORK_DIR/monitor-operations-team.json.tmp"
-  cp "$WORK_DIR/monitor-operations-team.json.tmp" "$WORK_DIR/monitor-operations-team.json"
-  rm "$WORK_DIR/monitor-operations-team.json.tmp"
-
-  # remove fields         "properties" "customerId" "dateCreated" "lastUpdated" "userCount"
-  jq '. |= del(.properties)' "$WORK_DIR/monitor-operations-team.json" > "$WORK_DIR/monitor-operations-team.json.tmp"
-  cp "$WORK_DIR/monitor-operations-team.json.tmp" "$WORK_DIR/monitor-operations-team.json"
-  rm "$WORK_DIR/monitor-operations-team.json.tmp"
-  jq '. |= del(.customerId)' "$WORK_DIR/monitor-operations-team.json" > "$WORK_DIR/monitor-operations-team.json.tmp"
-  cp "$WORK_DIR/monitor-operations-team.json.tmp" "$WORK_DIR/monitor-operations-team.json"
-  rm "$WORK_DIR/monitor-operations-team.json.tmp"
-  jq '. |= del(.dateCreated)' "$WORK_DIR/monitor-operations-team.json" > "$WORK_DIR/monitor-operations-team.json.tmp"
-  cp "$WORK_DIR/monitor-operations-team.json.tmp" "$WORK_DIR/monitor-operations-team.json"
-  rm "$WORK_DIR/monitor-operations-team.json.tmp"
-  jq '. |= del(.lastUpdated)' "$WORK_DIR/monitor-operations-team.json" > "$WORK_DIR/monitor-operations-team.json.tmp"
-  cp "$WORK_DIR/monitor-operations-team.json.tmp" "$WORK_DIR/monitor-operations-team.json"
-  rm "$WORK_DIR/monitor-operations-team.json.tmp"
-  jq '. |= del(.userCount)' "$WORK_DIR/monitor-operations-team.json" > "$WORK_DIR/monitor-operations-team.json.tmp"
-  cp "$WORK_DIR/monitor-operations-team.json.tmp" "$WORK_DIR/monitor-operations-team.json"
-  rm "$WORK_DIR/monitor-operations-team.json.tmp"
-
-  # add fields   "searchFilter" "filter"
-  jq --argjson var null '. + {searchFilter: $var}' "$WORK_DIR/monitor-operations-team.json" > "$WORK_DIR/monitor-operations-team.json.tmp"
-  cp "$WORK_DIR/monitor-operations-team.json.tmp" "$WORK_DIR/monitor-operations-team.json"
-  rm "$WORK_DIR/monitor-operations-team.json.tmp"
-  jq --argjson var null '. + {filter: $var}' "$WORK_DIR/monitor-operations-team.json" > "$WORK_DIR/monitor-operations-team.json.tmp"
-  cp "$WORK_DIR/monitor-operations-team.json.tmp" "$WORK_DIR/monitor-operations-team.json"
-  rm "$WORK_DIR/monitor-operations-team.json.tmp"
-
-  # add new user to group
-  # this is not working, we should remove existing users (account managers) and push only the new ones. 
-  # the get is returning account_managers
-  jq '.userRoles[.userRoles| length] |= . + {
-          "teamId": '${MONITOR_OPS_TEAM_ID}',
-          "teamName": "Monitor Operations",
-          "teamTheme": "#7BB0B2",
-          "userId": '"${SPA_USER_ID}"',
-          "userName": "'"${SPA_USER}"'",
-          "role": "ROLE_TEAM_ADVANCED"
-      }' "$WORK_DIR/monitor-operations-team.json" > "$WORK_DIR/monitor-operations-team.json.tmp"
-  cp "$WORK_DIR/monitor-operations-team.json.tmp" "$WORK_DIR/monitor-operations-team.json"
-  rm "$WORK_DIR/monitor-operations-team.json.tmp"
-
-
-  # update Monitor Operations team with new user assigned
+  # 4. Assign user to team with the correct role using Platform API
   curl -s -k -X PUT \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer ${ACCOUNT_PROVISIONER_MONITOR_API_TOKEN}" \
-  -d @$WORK_DIR/monitor-operations-team.json \
-  "${ACCOUNT_PROVISIONER_MONITOR_API_URL}"/api/teams/${MONITOR_OPS_TEAM_ID} \
-  | jq > /dev/null
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${ACCOUNT_PROVISIONER_MONITOR_API_TOKEN}" \
+    -d "$ROLE_PAYLOAD" \
+    "${PLATFORM_API_URL}/platform/v1/teams/${MONITOR_OPS_TEAM_ID}/users/${SPA_USER_ID}" \
+    | jq > /dev/null
 fi

--- a/common/prepare-track/account-provisioner-user-delete.sh
+++ b/common/prepare-track/account-provisioner-user-delete.sh
@@ -1,27 +1,46 @@
 #!/bin/bash
 
-set -xe
+set -xeo pipefail
 
 WORK_DIR=/opt/sysdig
-mkdir -p $WORK_DIR
 
 ##
 # User deprovisioner
 ##
 function user_deprovisioner () {
+    if [ ! -f "$WORK_DIR/account.json" ]; then
+        echo "No provisioned user metadata found. Skipping deprovisioning."
+        return 0
+    fi
 
     # parent account data
-    ACCOUNT_PROVISIONER_SECURE_API_TOKEN=$(cat $WORK_DIR/ACCOUNT_PROVISIONER_SECURE_API_TOKEN)
-    ACCOUNT_PROVISIONER_SECURE_API_URL=$(cat $WORK_DIR/ACCOUNT_PROVISIONER_SECURE_API_URL)
-    SPA_USER=$(cat $WORK_DIR/ACCOUNT_PROVISIONED_USER)
+    ACCOUNT_PROVISIONER_SECURE_API_TOKEN=$(<"$WORK_DIR/ACCOUNT_PROVISIONER_SECURE_API_TOKEN")
+    ACCOUNT_PROVISIONER_SECURE_API_URL=$(<"$WORK_DIR/ACCOUNT_PROVISIONER_SECURE_API_URL")
+    
+    # Get user ID from the account.json created during provisioning
+    # Note: The old provisioning API returns { "user": { "id": ... } }
+    SPA_USER_ID=$(jq '.user.id' "$WORK_DIR/account.json")
+    
+    # API Base URL for Platform
+    PLATFORM_API_URL=$(echo "${ACCOUNT_PROVISIONER_SECURE_API_URL}" | sed 's/app\./api./')
 
-    # delete user in parent account
-    curl -s -k -X DELETE \
-    -H "Content-Type: application/json" \
-    -H "Authorization: Bearer ${ACCOUNT_PROVISIONER_SECURE_API_TOKEN}" \
-    ${ACCOUNT_PROVISIONER_SECURE_API_URL}/api/users/${SPA_USER} \
-    | jq
-
+    if [ -n "$SPA_USER_ID" ] && [ "$SPA_USER_ID" != "null" ]; then
+        echo "Deleting user ID: $SPA_USER_ID"
+        # delete user in parent account using Platform API v1
+        curl -s -k -X DELETE \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer ${ACCOUNT_PROVISIONER_SECURE_API_TOKEN}" \
+        "${PLATFORM_API_URL}/platform/v1/users/${SPA_USER_ID}" \
+        | jq > /dev/null || true
+    else
+        echo "Could not find user ID in account.json. Attempting fallback delete by username..."
+        SPA_USER=$(<"$WORK_DIR/ACCOUNT_PROVISIONED_USER")
+        curl -s -k -X DELETE \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer ${ACCOUNT_PROVISIONER_SECURE_API_TOKEN}" \
+        "${ACCOUNT_PROVISIONER_SECURE_API_URL}/api/users/${SPA_USER}" \
+        | jq > /dev/null || true
+    fi
 }
 
 user_deprovisioner


### PR DESCRIPTION
This is a corrected version of PR #187. 

It keeps the old /api/user/provisioning/ endpoint to ensure the student's API Token is returned (which is required by init.sh), but it uses the modern /platform/v1/ API for:
- Dynamic role lookup for 'Advanced with Sage Access'.
- Team assignment using PUT /platform/v1/teams/{teamId}/users/{userId}.
- User deletion using DELETE /platform/v1/users/{userId}.