### PR TITLE
Migrate pre-commit secret scanner from TruffleHog to ggshield

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,10 @@
 repos:
-  - repo: local
+  - repo: https://github.com/gitguardian/ggshield
+    rev: v1.50.4
     hooks:
-      - id: trufflehog
-        name: TruffleHog
-        description: Detect secrets in your data.
-        entry: bash -c 'trufflehog git file://. --since-commit HEAD --results=verified --fail'
-        # For running trufflehog in docker, use the following entry instead:
-        # entry: bash -c 'docker run --rm -v "$(pwd):/workdir" -i --rm trufflesecurity/trufflehog:latest git file:///workdir --since-commit HEAD --results=verified,unknown --fail'
-        language: system
-        stages: ["commit", "push"]
+      - id: ggshield
+        language_version: python3
+        stages: [commit]
+      - id: ggshield-push
+        language_version: python3
+        stages: [push]


### PR DESCRIPTION
## Summary

Replace the local TruffleHog pre-commit hook with the upstream GitGuardian `ggshield` hook (pinned to `v1.50.4`).

Part of the org-wide pre-commit secret-scanner standardization. JIRA tracking ticket: SECCOMP-67807.

## Changes

- `.pre-commit-config.yaml`: drop the local `trufflehog` binary hook; add `ggshield` (commit stage) and `ggshield-push` (push stage) from `gitguardian/ggshield@v1.50.4`.

## Prerequisites for developers

After this PR lands, you need `ggshield` installed and `GITGUARDIAN_API_KEY` set locally to commit:

```bash
brew install gitguardian/tap/ggshield   # or: pip install ggshield
ggshield auth login
```

## Test plan

- [ ] On a clean local checkout with `GITGUARDIAN_API_KEY` set, `pre-commit install && pre-commit run --all-files ggshield` exits clean
- [ ] Introducing a fake secret triggers ggshield and blocks the commit
- [ ] No leftover `trufflehog` references
