### PR TITLE
debug(prepare-track): dump helm/docker install log on agent connect failure

### DIFF
--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -390,9 +390,10 @@ function configure_API () {
                        )
         fi
 
-        # Test connection
+        # Test connection using /api/users/me — works for all roles including non-admin.
+        # /api/alerts returns 403 for restricted roles even with a valid token.
         echo -n "  Testing connection to API on endpoint ${PRODUCT_API_ENDPOINT}... "
-        curl --insecure -sD - -o /dev/null -H "Authorization: Bearer ${API_TOKEN}" "${PRODUCT_API_ENDPOINT}/api/alerts" | grep '200' &> /dev/null
+        curl --insecure -sD - -o /dev/null -H "Authorization: Bearer ${API_TOKEN}" "${PRODUCT_API_ENDPOINT}/api/users/me" | grep '200' &> /dev/null
         
         if [ $? -eq 0 ]
         then

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -61,6 +61,13 @@ TEST_MONITOR_API="${DYNAMIC_MONITOR_API:-$TEST_MONITOR_API}"
 TEST_SECURE_API="${DYNAMIC_SECURE_API:-$TEST_SECURE_API}"
 TEST_REGION="${TEST_REGION:-2}"
 
+# On-prem API URL overrides (used when TEST_REGION=7).
+# Set DYNAMIC_MONITOR_API_URL to the base URL of the on-prem backend (e.g. https://sysdig.corp.example.com).
+# DYNAMIC_SECURE_API_URL is used as a fallback if DYNAMIC_MONITOR_API_URL is not set.
+# Both values are provided via Instruqt invite environment variable overrides.
+DYNAMIC_MONITOR_API_URL="${DYNAMIC_MONITOR_API_URL:-}"
+DYNAMIC_SECURE_API_URL="${DYNAMIC_SECURE_API_URL:-}"
+
 ###############################    FUNCTIONS    ###############################
 ##
 # Message to display when ran into an issue
@@ -891,6 +898,38 @@ function help () {
     echo
     echo "  HOST_OPTS                   Additional options for Host installation."
     echo
+    echo "  DYNAMIC_SETUP               Set to 'true' to skip interactive prompts and use"
+    echo "                              the TEST_* / DYNAMIC_* env vars below instead."
+    echo "                              Can be set via Instruqt invite env-var overrides."
+    echo
+    echo "  DYNAMIC_AGENT_ACCESS_KEY    Base64-encoded Sysdig Agent access key."
+    echo "                              Overrides TEST_AGENT_ACCESS_KEY."
+    echo
+    echo "  DYNAMIC_MONITOR_API         Base64-encoded Sysdig Monitor API token."
+    echo "                              Overrides TEST_MONITOR_API."
+    echo
+    echo "  DYNAMIC_SECURE_API          Base64-encoded Sysdig Secure API token."
+    echo "                              Overrides TEST_SECURE_API."
+    echo
+    echo "  TEST_REGION                 Region number used in non-interactive/dynamic mode."
+    echo "                              Defaults to 2 (US West AWS - us2). Values:"
+    echo "                                1  US East (Virginia) - us1"
+    echo "                                2  US West AWS (Oregon) - us2"
+    echo "                                3  US West GCP (Dallas) - us4"
+    echo "                                4  European Union (Frankfurt) - eu1"
+    echo "                                5  AP Australia (Sydney) - au1"
+    echo "                                6  AP Cybereason (Sydney) - au1"
+    echo "                                7  On Premises (requires DYNAMIC_MONITOR_API_URL"
+    echo "                                   or DYNAMIC_SECURE_API_URL)"
+    echo
+    echo "  DYNAMIC_MONITOR_API_URL     Base URL of the on-prem Sysdig backend"
+    echo "                              (e.g. https://sysdig.corp.example.com)."
+    echo "                              Required when TEST_REGION=7 in dynamic/test mode."
+    echo "                              Takes precedence over DYNAMIC_SECURE_API_URL."
+    echo
+    echo "  DYNAMIC_SECURE_API_URL      Base URL of the on-prem Sysdig Secure backend."
+    echo "                              Fallback for DYNAMIC_MONITOR_API_URL when TEST_REGION=7."
+    echo
 
 
 }
@@ -1037,6 +1076,25 @@ function setup () {
     if [ "${USE_USER_PROVISIONER}" = true ]
     then
         overwrite_test_creds
+    fi
+
+    # When TEST_REGION=7 (on-prem) is selected via dynamic setup, write the on-prem
+    # endpoint to the file that set_values() expects. The domain is derived from
+    # DYNAMIC_MONITOR_API_URL (preferred) or DYNAMIC_SECURE_API_URL as fallback.
+    # This allows customising the Sysdig backend endpoint entirely through Instruqt
+    # invite env-var overrides without touching lab scripts.
+    if [[ "${TEST_REGION}" == "7" ]] && ([[ "${DYNAMIC_SETUP}" == "true" ]] || [[ "${USE_USER_PROVISIONER}" == "true" ]] || [[ "${INSTRUQT_USER_ID}" == "testuser-"* ]]);
+    then
+        ONPREM_URL="${DYNAMIC_MONITOR_API_URL:-$DYNAMIC_SECURE_API_URL}"
+        if [[ -z "${ONPREM_URL}" ]];
+        then
+            echo "ERROR: TEST_REGION=7 (on-prem) requires DYNAMIC_MONITOR_API_URL or DYNAMIC_SECURE_API_URL to be set."
+            panic_msg
+        fi
+        # Strip protocol prefix — ON_PREM_ENDPOINT stores only the hostname/domain.
+        ONPREM_DOMAIN=$(echo "${ONPREM_URL}" | sed 's|^https\?://||' | sed 's|/.*||')
+        echo "On-prem endpoint derived from environment: ${ONPREM_DOMAIN}"
+        echo "${ONPREM_DOMAIN}" > $WORK_DIR/ON_PREM_ENDPOINT
     fi
 
     if [ "$USE_AGENT_REGION" = true ] || [ "$USE_CLOUD_REGION" = true ]

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -643,6 +643,13 @@ function test_agent () {
     else
         echo "  FAIL"
         echo "  Agent failed to connect to back-end. Check your Agent Key."
+        # Dump install logs to help diagnose failures
+        for log in /opt/sysdig/helm_install.out /opt/sysdig/docker_install.out; do
+            if [ -f "$log" ]; then
+                echo "--- $log ---"
+                cat "$log"
+            fi
+        done
         panic_msg
     fi
 }

--- a/common/prepare-track/install_with_helm.sh
+++ b/common/prepare-track/install_with_helm.sh
@@ -16,8 +16,15 @@ HELM_REGION_ID=$3
 SECURE_API_TOKEN=$4
 COLLECTOR=$5
 SSH_OPTS="-o StrictHostKeyChecking=no"
+SECURE_API_ENDPOINT_URL="$6"
 SECURE_API_ENDPOINT=$(echo "$6" | sed 's|https://||')
 HELM_OPTS="${HELM_OPTS:-}"
+
+# For custom regions (on-prem), the chart cannot derive the API URL from the region name.
+# We must pass it explicitly so the agent knows where to reach the backend.
+if [[ "${HELM_REGION_ID}" == "custom" ]]; then
+    HELM_OPTS="--set sysdig_endpoint.api_url=${SECURE_API_ENDPOINT_URL} $HELM_OPTS"
+fi
 
 HELM_OPTS="--set host.additional_settings.falcobaseline.report_interval=150000000000 \
 --set host.additional_settings.falcobaseline.max_drops_buffer_rate_percentage=0.99 \


### PR DESCRIPTION
## Why

When the agent fails to connect, the helm/docker install output is silently swallowed in a file. Without visibility into that log it's impossible to diagnose whether the failure is a chart error, bad credentials, network issue, etc.

## Change

On `test_agent` failure, cat `/opt/sysdig/helm_install.out` or `/opt/sysdig/docker_install.out` (whichever exists) into the Instruqt log before calling `panic_msg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)