### PR TITLE
fix(prepare-track): on-prem support via env vars (TEST_REGION=7)

### DIFF
--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -390,9 +390,10 @@ function configure_API () {
                        )
         fi
 
-        # Test connection
+        # Test connection using /api/users/me — works for all roles including non-admin.
+        # /api/alerts returns 403 for restricted roles even with a valid token.
         echo -n "  Testing connection to API on endpoint ${PRODUCT_API_ENDPOINT}... "
-        curl --insecure -sD - -o /dev/null -H "Authorization: Bearer ${API_TOKEN}" "${PRODUCT_API_ENDPOINT}/api/alerts" | grep '200' &> /dev/null
+        curl --insecure -sD - -o /dev/null -H "Authorization: Bearer ${API_TOKEN}" "${PRODUCT_API_ENDPOINT}/api/users/me" | grep '200' &> /dev/null
         
         if [ $? -eq 0 ]
         then

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -1111,17 +1111,21 @@ function setup () {
         echo "${ONPREM_DOMAIN}" > $WORK_DIR/ON_PREM_ENDPOINT
 
         # Probe the collector port independently — 6443 is the standard on-prem collector
-        # port; fall back to 443 if unreachable. The probe is non-fatal: we capture the
-        # HTTP status code and treat anything other than "000" (no connection) as success.
-        DYNAMIC_COLLECTOR_PORT=6443
-        for try_port in 6443 443; do
-            HTTP_CODE=$(curl --insecure -s --connect-timeout 3 -o /dev/null \
-                -w "%{http_code}" "https://${ONPREM_DOMAIN}:${try_port}/" 2>/dev/null) || true
-            if [[ -n "${HTTP_CODE}" ]] && [[ "${HTTP_CODE}" != "000" ]]; then
-                DYNAMIC_COLLECTOR_PORT=${try_port}
-                break
-            fi
-        done
+        # port; fall back to 443 if unreachable. Both --connect-timeout AND --max-time are
+        # required: --connect-timeout alone does not bound SYN-drop (firewalled) ports
+        # because the TCP stack keeps retrying; --max-time enforces a hard wall-clock cap.
+        # The probe is non-fatal (|| true). Skip if already set by invite env-var override.
+        if [[ -z "${DYNAMIC_COLLECTOR_PORT}" ]]; then
+            DYNAMIC_COLLECTOR_PORT=6443
+            for try_port in 6443 443; do
+                HTTP_CODE=$(curl --insecure -s --connect-timeout 3 --max-time 4 -o /dev/null \
+                    -w "%{http_code}" "https://${ONPREM_DOMAIN}:${try_port}/" 2>/dev/null) || true
+                if [[ -n "${HTTP_CODE}" ]] && [[ "${HTTP_CODE}" != "000" ]]; then
+                    DYNAMIC_COLLECTOR_PORT=${try_port}
+                    break
+                fi
+            done
+        fi
         export DYNAMIC_COLLECTOR_PORT
 
         if [[ "${DYNAMIC_COLLECTOR_PORT}" != "6443" ]]; then

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -61,6 +61,13 @@ TEST_MONITOR_API="${DYNAMIC_MONITOR_API:-$TEST_MONITOR_API}"
 TEST_SECURE_API="${DYNAMIC_SECURE_API:-$TEST_SECURE_API}"
 TEST_REGION="${TEST_REGION:-2}"
 
+# On-prem API URL overrides (used when TEST_REGION=7).
+# Set DYNAMIC_MONITOR_API_URL to the base URL of the on-prem backend (e.g. https://sysdig.corp.example.com).
+# DYNAMIC_SECURE_API_URL is used as a fallback if DYNAMIC_MONITOR_API_URL is not set.
+# Both values are provided via Instruqt invite environment variable overrides.
+DYNAMIC_MONITOR_API_URL="${DYNAMIC_MONITOR_API_URL:-}"
+DYNAMIC_SECURE_API_URL="${DYNAMIC_SECURE_API_URL:-}"
+
 ###############################    FUNCTIONS    ###############################
 ##
 # Message to display when ran into an issue
@@ -891,6 +898,38 @@ function help () {
     echo
     echo "  HOST_OPTS                   Additional options for Host installation."
     echo
+    echo "  DYNAMIC_SETUP               Set to 'true' to skip interactive prompts and use"
+    echo "                              the TEST_* / DYNAMIC_* env vars below instead."
+    echo "                              Can be set via Instruqt invite env-var overrides."
+    echo
+    echo "  DYNAMIC_AGENT_ACCESS_KEY    Base64-encoded Sysdig Agent access key."
+    echo "                              Overrides TEST_AGENT_ACCESS_KEY."
+    echo
+    echo "  DYNAMIC_MONITOR_API         Base64-encoded Sysdig Monitor API token."
+    echo "                              Overrides TEST_MONITOR_API."
+    echo
+    echo "  DYNAMIC_SECURE_API          Base64-encoded Sysdig Secure API token."
+    echo "                              Overrides TEST_SECURE_API."
+    echo
+    echo "  TEST_REGION                 Region number used in non-interactive/dynamic mode."
+    echo "                              Defaults to 2 (US West AWS - us2). Values:"
+    echo "                                1  US East (Virginia) - us1"
+    echo "                                2  US West AWS (Oregon) - us2"
+    echo "                                3  US West GCP (Dallas) - us4"
+    echo "                                4  European Union (Frankfurt) - eu1"
+    echo "                                5  AP Australia (Sydney) - au1"
+    echo "                                6  AP Cybereason (Sydney) - au1"
+    echo "                                7  On Premises (requires DYNAMIC_MONITOR_API_URL"
+    echo "                                   or DYNAMIC_SECURE_API_URL)"
+    echo
+    echo "  DYNAMIC_MONITOR_API_URL     Base URL of the on-prem Sysdig backend"
+    echo "                              (e.g. https://sysdig.corp.example.com)."
+    echo "                              Required when TEST_REGION=7 in dynamic/test mode."
+    echo "                              Takes precedence over DYNAMIC_SECURE_API_URL."
+    echo
+    echo "  DYNAMIC_SECURE_API_URL      Base URL of the on-prem Sysdig Secure backend."
+    echo "                              Fallback for DYNAMIC_MONITOR_API_URL when TEST_REGION=7."
+    echo
 
 
 }
@@ -1037,6 +1076,25 @@ function setup () {
     if [ "${USE_USER_PROVISIONER}" = true ]
     then
         overwrite_test_creds
+    fi
+
+    # When TEST_REGION=7 (on-prem) is selected via dynamic setup, write the on-prem
+    # endpoint to the file that set_values() expects. The domain is derived from
+    # DYNAMIC_MONITOR_API_URL (preferred) or DYNAMIC_SECURE_API_URL as fallback.
+    # This allows customising the Sysdig backend endpoint entirely through Instruqt
+    # invite env-var overrides without touching lab scripts.
+    if [[ "${TEST_REGION}" == "7" ]] && ([[ "${DYNAMIC_SETUP}" == "true" ]] || [[ "${USE_USER_PROVISIONER}" == "true" ]] || [[ "${INSTRUQT_USER_ID}" == "testuser-"* ]]);
+    then
+        ONPREM_URL="${DYNAMIC_MONITOR_API_URL:-$DYNAMIC_SECURE_API_URL}"
+        if [[ -z "${ONPREM_URL}" ]];
+        then
+            echo "ERROR: TEST_REGION=7 (on-prem) requires DYNAMIC_MONITOR_API_URL or DYNAMIC_SECURE_API_URL to be set."
+            panic_msg
+        fi
+        # Strip protocol prefix — ON_PREM_ENDPOINT stores only the hostname/domain.
+        ONPREM_DOMAIN=$(echo "${ONPREM_URL}" | sed 's|^https\?://||' | sed 's|/.*||')
+        echo "On-prem endpoint derived from environment: ${ONPREM_DOMAIN}"
+        echo "${ONPREM_DOMAIN}" > $WORK_DIR/ON_PREM_ENDPOINT
     fi
 
     if [ "$USE_AGENT_REGION" = true ] || [ "$USE_CLOUD_REGION" = true ]

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -64,11 +64,10 @@ TEST_REGION="${TEST_REGION:-2}"
 # On-prem overrides (used when TEST_REGION=7).
 # All values can be set via Instruqt invite environment variable overrides.
 # DYNAMIC_MONITOR_API_URL takes precedence over DYNAMIC_SECURE_API_URL for the backend URL.
+# Include the collector port in the URL if it differs from the default (e.g. https://host:6443).
+# If no port is given, the script probes 6443 then 443 and warns when falling back.
 DYNAMIC_MONITOR_API_URL="${DYNAMIC_MONITOR_API_URL:-}"
 DYNAMIC_SECURE_API_URL="${DYNAMIC_SECURE_API_URL:-}"
-# Collector port for on-prem backends. Defaults to 6443 (standard Sysdig on-prem port).
-DYNAMIC_COLLECTOR_PORT="${DYNAMIC_COLLECTOR_PORT:-6443}"
-export DYNAMIC_COLLECTOR_PORT
 
 ###############################    FUNCTIONS    ###############################
 ##
@@ -939,10 +938,9 @@ function help () {
     echo
     echo "  DYNAMIC_SECURE_API_URL      Base URL of the on-prem Sysdig Secure backend."
     echo "                              Fallback for DYNAMIC_MONITOR_API_URL when TEST_REGION=7."
-    echo
-    echo "  DYNAMIC_COLLECTOR_PORT      Collector port for the on-prem backend."
-    echo "                              Defaults to 6443 (standard Sysdig on-prem port)."
-    echo "                              Only used when TEST_REGION=7."
+    echo "                              Include the collector port in the URL to set it explicitly"
+    echo "                              (e.g. https://sysdig.corp.example.com:6443). If no port is"
+    echo "                              given, the script probes 6443 then 443 and warns on fallback."
     echo
 
 
@@ -1105,9 +1103,32 @@ function setup () {
             echo "ERROR: TEST_REGION=7 (on-prem) requires DYNAMIC_MONITOR_API_URL or DYNAMIC_SECURE_API_URL to be set."
             panic_msg
         fi
-        # Strip protocol prefix — ON_PREM_ENDPOINT stores only the hostname/domain.
-        ONPREM_DOMAIN=$(echo "${ONPREM_URL}" | sed 's|^https\?://||' | sed 's|/.*||')
-        echo "On-prem endpoint derived from environment: ${ONPREM_DOMAIN}"
+        # Strip protocol and path — ON_PREM_ENDPOINT stores only the hostname/domain.
+        ONPREM_HOSTPORT=$(echo "${ONPREM_URL}" | sed 's|^https\?://||' | sed 's|/.*||')
+        ONPREM_DOMAIN=$(echo "${ONPREM_HOSTPORT}" | cut -d: -f1)
+
+        # Determine collector port: use the port from the URL if explicit (e.g. https://host:6443),
+        # otherwise probe known on-prem ports (6443, then 443) and warn when falling back.
+        if echo "${ONPREM_HOSTPORT}" | grep -q ':'; then
+            export DYNAMIC_COLLECTOR_PORT=$(echo "${ONPREM_HOSTPORT}" | cut -d: -f2)
+            echo "On-prem collector port from URL: ${DYNAMIC_COLLECTOR_PORT}"
+        else
+            export DYNAMIC_COLLECTOR_PORT=6443
+            for try_port in 6443 443; do
+                if curl --insecure -s --connect-timeout 3 -o /dev/null \
+                        "https://${ONPREM_DOMAIN}:${try_port}/api/ping" 2>/dev/null; then
+                    export DYNAMIC_COLLECTOR_PORT=${try_port}
+                    break
+                fi
+            done
+            if [[ "${DYNAMIC_COLLECTOR_PORT}" != "6443" ]]; then
+                echo "WARNING: port 6443 unreachable on ${ONPREM_DOMAIN}, using collector port ${DYNAMIC_COLLECTOR_PORT}."
+            else
+                echo "On-prem collector port: 6443 (default)"
+            fi
+        fi
+
+        echo "On-prem endpoint: ${ONPREM_DOMAIN}:${DYNAMIC_COLLECTOR_PORT}"
         echo "${ONPREM_DOMAIN}" > $WORK_DIR/ON_PREM_ENDPOINT
     fi
 

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -643,6 +643,13 @@ function test_agent () {
     else
         echo "  FAIL"
         echo "  Agent failed to connect to back-end. Check your Agent Key."
+        # Dump install logs to help diagnose failures
+        for log in /opt/sysdig/helm_install.out /opt/sysdig/docker_install.out; do
+            if [ -f "$log" ]; then
+                echo "--- $log ---"
+                cat "$log"
+            fi
+        done
         panic_msg
     fi
 }

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -61,12 +61,14 @@ TEST_MONITOR_API="${DYNAMIC_MONITOR_API:-$TEST_MONITOR_API}"
 TEST_SECURE_API="${DYNAMIC_SECURE_API:-$TEST_SECURE_API}"
 TEST_REGION="${TEST_REGION:-2}"
 
-# On-prem API URL overrides (used when TEST_REGION=7).
-# Set DYNAMIC_MONITOR_API_URL to the base URL of the on-prem backend (e.g. https://sysdig.corp.example.com).
-# DYNAMIC_SECURE_API_URL is used as a fallback if DYNAMIC_MONITOR_API_URL is not set.
-# Both values are provided via Instruqt invite environment variable overrides.
+# On-prem overrides (used when TEST_REGION=7).
+# All values can be set via Instruqt invite environment variable overrides.
+# DYNAMIC_MONITOR_API_URL takes precedence over DYNAMIC_SECURE_API_URL for the backend URL.
 DYNAMIC_MONITOR_API_URL="${DYNAMIC_MONITOR_API_URL:-}"
 DYNAMIC_SECURE_API_URL="${DYNAMIC_SECURE_API_URL:-}"
+# Collector port for on-prem backends. Defaults to 6443 (standard Sysdig on-prem port).
+DYNAMIC_COLLECTOR_PORT="${DYNAMIC_COLLECTOR_PORT:-6443}"
+export DYNAMIC_COLLECTOR_PORT
 
 ###############################    FUNCTIONS    ###############################
 ##
@@ -937,6 +939,10 @@ function help () {
     echo
     echo "  DYNAMIC_SECURE_API_URL      Base URL of the on-prem Sysdig Secure backend."
     echo "                              Fallback for DYNAMIC_MONITOR_API_URL when TEST_REGION=7."
+    echo
+    echo "  DYNAMIC_COLLECTOR_PORT      Collector port for the on-prem backend."
+    echo "                              Defaults to 6443 (standard Sysdig on-prem port)."
+    echo "                              Only used when TEST_REGION=7."
     echo
 
 

--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -1103,33 +1103,32 @@ function setup () {
             echo "ERROR: TEST_REGION=7 (on-prem) requires DYNAMIC_MONITOR_API_URL or DYNAMIC_SECURE_API_URL to be set."
             panic_msg
         fi
-        # Strip protocol and path — ON_PREM_ENDPOINT stores only the hostname/domain.
-        ONPREM_HOSTPORT=$(echo "${ONPREM_URL}" | sed 's|^https\?://||' | sed 's|/.*||')
-        ONPREM_DOMAIN=$(echo "${ONPREM_HOSTPORT}" | cut -d: -f1)
-
-        # Determine collector port: use the port from the URL if explicit (e.g. https://host:6443),
-        # otherwise probe known on-prem ports (6443, then 443) and warn when falling back.
-        if echo "${ONPREM_HOSTPORT}" | grep -q ':'; then
-            export DYNAMIC_COLLECTOR_PORT=$(echo "${ONPREM_HOSTPORT}" | cut -d: -f2)
-            echo "On-prem collector port from URL: ${DYNAMIC_COLLECTOR_PORT}"
-        else
-            export DYNAMIC_COLLECTOR_PORT=6443
-            for try_port in 6443 443; do
-                if curl --insecure -s --connect-timeout 3 -o /dev/null \
-                        "https://${ONPREM_DOMAIN}:${try_port}/api/ping" 2>/dev/null; then
-                    export DYNAMIC_COLLECTOR_PORT=${try_port}
-                    break
-                fi
-            done
-            if [[ "${DYNAMIC_COLLECTOR_PORT}" != "6443" ]]; then
-                echo "WARNING: port 6443 unreachable on ${ONPREM_DOMAIN}, using collector port ${DYNAMIC_COLLECTOR_PORT}."
-            else
-                echo "On-prem collector port: 6443 (default)"
-            fi
-        fi
-
-        echo "On-prem endpoint: ${ONPREM_DOMAIN}:${DYNAMIC_COLLECTOR_PORT}"
+        # Extract clean hostname (strip protocol, any explicit port, and path).
+        # ON_PREM_ENDPOINT stores only the hostname so set_values() builds the API URL
+        # as https://<domain> (port 443). API calls and agent collector use different ports.
+        ONPREM_DOMAIN=$(echo "${ONPREM_URL}" | sed 's|^https\?://||' | cut -d: -f1 | cut -d/ -f1)
+        echo "On-prem domain: ${ONPREM_DOMAIN}"
         echo "${ONPREM_DOMAIN}" > $WORK_DIR/ON_PREM_ENDPOINT
+
+        # Probe the collector port independently — 6443 is the standard on-prem collector
+        # port; fall back to 443 if unreachable. The probe is non-fatal: we capture the
+        # HTTP status code and treat anything other than "000" (no connection) as success.
+        DYNAMIC_COLLECTOR_PORT=6443
+        for try_port in 6443 443; do
+            HTTP_CODE=$(curl --insecure -s --connect-timeout 3 -o /dev/null \
+                -w "%{http_code}" "https://${ONPREM_DOMAIN}:${try_port}/" 2>/dev/null) || true
+            if [[ -n "${HTTP_CODE}" ]] && [[ "${HTTP_CODE}" != "000" ]]; then
+                DYNAMIC_COLLECTOR_PORT=${try_port}
+                break
+            fi
+        done
+        export DYNAMIC_COLLECTOR_PORT
+
+        if [[ "${DYNAMIC_COLLECTOR_PORT}" != "6443" ]]; then
+            echo "WARNING: collector port 6443 unreachable on ${ONPREM_DOMAIN}, falling back to port ${DYNAMIC_COLLECTOR_PORT}."
+        else
+            echo "On-prem collector port: ${DYNAMIC_COLLECTOR_PORT}"
+        fi
     fi
 
     if [ "$USE_AGENT_REGION" = true ] || [ "$USE_CLOUD_REGION" = true ]

--- a/common/prepare-track/install_with_helm.sh
+++ b/common/prepare-track/install_with_helm.sh
@@ -23,7 +23,7 @@ HELM_OPTS="${HELM_OPTS:-}"
 # For custom regions (on-prem), the chart cannot derive the API URL from the region name.
 # We must pass it explicitly so the agent knows where to reach the backend.
 if [[ "${HELM_REGION_ID}" == "custom" ]]; then
-    HELM_OPTS="--set sysdig_endpoint.api_url=${SECURE_API_ENDPOINT_URL} $HELM_OPTS"
+    HELM_OPTS="--set sysdig_endpoint.api_url=${SECURE_API_ENDPOINT_URL} --set sysdig_endpoint.collector.port=${DYNAMIC_COLLECTOR_PORT:-6443} $HELM_OPTS"
 fi
 
 HELM_OPTS="--set host.additional_settings.falcobaseline.report_interval=150000000000 \

--- a/common/prepare-track/install_with_helm.sh
+++ b/common/prepare-track/install_with_helm.sh
@@ -16,8 +16,15 @@ HELM_REGION_ID=$3
 SECURE_API_TOKEN=$4
 COLLECTOR=$5
 SSH_OPTS="-o StrictHostKeyChecking=no"
+SECURE_API_ENDPOINT_URL="$6"
 SECURE_API_ENDPOINT=$(echo "$6" | sed 's|https://||')
 HELM_OPTS="${HELM_OPTS:-}"
+
+# For custom regions (on-prem), the chart cannot derive the API URL from the region name.
+# We must pass it explicitly so the agent knows where to reach the backend.
+if [[ "${HELM_REGION_ID}" == "custom" ]]; then
+    HELM_OPTS="--set sysdig_endpoint.api_url=${SECURE_API_ENDPOINT_URL} $HELM_OPTS"
+fi
 
 HELM_OPTS="--set host.additional_settings.falcobaseline.report_interval=150000000000 \
 --set host.additional_settings.falcobaseline.max_drops_buffer_rate_percentage=0.99 \

--- a/common/prepare-track/install_with_helm.sh
+++ b/common/prepare-track/install_with_helm.sh
@@ -141,6 +141,6 @@ kubectl create ns sysdig-agent >> ${OUTPUT} 2>&1
     --set features.investigations.captures.enabled=true \
     --set ssl.verify=false \
     --set sysdig_endpoint.collector.host="${COLLECTOR}" ${HELM_OPTS} \
-sysdig/shield >> ${OUTPUT} 2>&1)
+sysdig/shield 2>&1 | tee ${OUTPUT})
 
 # kubectl wait --for=condition=Ready daemonset/sysdig-agent -n sysdig-agent --timeout=300s


### PR DESCRIPTION
## Summary

- When `TEST_REGION=7`, reads `DYNAMIC_MONITOR_API_URL` (or `DYNAMIC_SECURE_API_URL` as fallback) to configure the on-prem Sysdig endpoint — no lab script edits needed, Instruqt invite env-var overrides are enough
- Separates API URL (port 443) from agent collector port (default 6443) — the helm chart requires these as distinct values
- Probes the collector port on startup with a per-attempt hard timeout (`--connect-timeout 3 --max-time 4`) so SYN-drop firewalled ports fail fast instead of blocking for ~60 s; falls back to 443 with a warning if 6443 is unreachable
- `DYNAMIC_COLLECTOR_PORT` can be set via invite env-var to bypass the probe entirely and pin a specific port
- Passes `sysdig_endpoint.api_url` and `sysdig_endpoint.collector.port` explicitly in the helm command for `region=custom` (chart cannot derive the API URL from the region name in on-prem deployments, and the JSON schema requires the port as an integer)
- Changed API health-check endpoint from `/api/alerts` (returns 403 for non-admin roles) to `/api/users/me` (returns 200 for any valid token)
- Helm output piped through `tee` so it appears in Instruqt logs for easier debugging
- Helm/docker install log dumped on agent connect failure

## Test plan

- [ ] Start a lab with default secrets (no `TEST_REGION` override) — existing behaviour unchanged
- [ ] Start a lab with `TEST_REGION=7` and `DYNAMIC_MONITOR_API_URL=https://<on-prem-host>` — agent deploys against on-prem backend, collector uses port 6443
- [ ] Start with `TEST_REGION=7` and `DYNAMIC_COLLECTOR_PORT=443` — probe is skipped, helm uses port 443
- [ ] Start with `TEST_REGION=7` but no API URL set — script prints an error and calls `panic_msg`
- [ ] Verify helm output visible in Instruqt sandbox logs (not just the output file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)