### PR TITLE
fix(prepare-track): avoid unbound variable crash with set -u for DYNAMIC_COLLECTOR_PORT

### DIFF
--- a/common/prepare-track/init.sh
+++ b/common/prepare-track/init.sh
@@ -1115,7 +1115,7 @@ function setup () {
         # required: --connect-timeout alone does not bound SYN-drop (firewalled) ports
         # because the TCP stack keeps retrying; --max-time enforces a hard wall-clock cap.
         # The probe is non-fatal (|| true). Skip if already set by invite env-var override.
-        if [[ -z "${DYNAMIC_COLLECTOR_PORT}" ]]; then
+        if [[ -z "${DYNAMIC_COLLECTOR_PORT:-}" ]]; then
             DYNAMIC_COLLECTOR_PORT=6443
             for try_port in 6443 443; do
                 HTTP_CODE=$(curl --insecure -s --connect-timeout 3 --max-time 4 -o /dev/null \


### PR DESCRIPTION
## Summary

- `DYNAMIC_COLLECTOR_PORT` is unset on first run; referencing it unguarded under `set -u` caused the script to crash immediately after writing `ON_PREM_ENDPOINT`
- Changed `[[ -z "${DYNAMIC_COLLECTOR_PORT}" ]]` → `[[ -z "${DYNAMIC_COLLECTOR_PORT:-}" ]]` so the empty check safely expands to an empty string when the variable is unset

## Root cause

Observed in lab logs:
```
/root/prepare-track/init.sh: line 1118: DYNAMIC_COLLECTOR_PORT: unbound variable
Process exited with status 1
```

The `:-` default expansion is the standard bash idiom for guarding against `set -u` on optional variables.

## Test plan

- [ ] Start a lab with `TEST_REGION=7` and `DYNAMIC_MONITOR_API_URL` set — script should proceed past the collector port probe without crashing
- [ ] Start with `TEST_REGION=7` and `DYNAMIC_COLLECTOR_PORT=6443` already set — probe should be skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)