### PR TITLE
fix(headless-playground): add resource limits to orders-api and debug-tools

### DIFF
--- a/secure/headless-cnapp-playground/infra/k8s/debug-tools.yaml
+++ b/secure/headless-cnapp-playground/infra/k8s/debug-tools.yaml
@@ -14,4 +14,11 @@ spec:
     - name: tools
       image: nicolaka/netshoot:latest
       command: ["sleep", "infinity"]
+      resources:
+        requests:
+          cpu: "50m"
+          memory: "32Mi"
+        limits:
+          cpu: "200m"
+          memory: "256Mi"
   restartPolicy: Always

--- a/secure/headless-cnapp-playground/infra/k8s/orders-api.yaml
+++ b/secure/headless-cnapp-playground/infra/k8s/orders-api.yaml
@@ -87,6 +87,17 @@ spec:
             - secretRef:
                 name: app-cloud-creds
                 optional: true
+          # Limits scope xmrig OOM kills to this container's cgroup
+          # (CONSTRAINT_MEMCG) instead of triggering a global node OOM that
+          # takes down the apiserver. 512 Mi is enough for xmrig to exec and
+          # be detected by Sysdig before being killed; Python survives (~50 Mi).
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "64Mi"
+            limits:
+              cpu: "1000m"
+              memory: "512Mi"
           volumeMounts:
             - name: code
               mountPath: /app


### PR DESCRIPTION
## Problem

Both `orders-api` and `debug-tools` pods deploy as **BestEffort** (no resource limits). When the attack phase launches xmrig via the `orders-api` webshell, xmrig grows to ~2.4 GB RSS with no container-level cap. This triggers a **global node OOM** (`CONSTRAINT_NONE`) that takes down the apiserver, etcd, and scheduler — making `kubectl` intermittently fail throughout the lab.

Root cause was diagnosed live by Claude Code running inside the lab:

- xmrig OOM-killed in cgroup `cri-containerd-11c8f2cfb006…` (same container as `orders-api`)
- Load avg peaked at **47–56 on a 4-core node** (~12× overload)
- `NodeNotReady` event + control-plane pod flaps at ~17 min into the run
- The `while true` relaunch loop in the attack command creates a bursty OOM cycle

Note: the `-t 1` flag on xmrig (added earlier) limits CPU threads but **not memory** — xmrig still grows to 2.4 GB RSS regardless. The fix has to be at the pod level.

## Fix

**`orders-api`**: add `memory: limit: 512Mi`. When xmrig exceeds 512 Mi inside the container cgroup, the kernel fires a `CONSTRAINT_MEMCG` OOM that kills xmrig (largest RSS in the cgroup) while leaving Python's `server.py` alive (~50 Mi). Node stays healthy. The webshell survives for the rest of the attack chain.

Sysdig detections are **unaffected**: Malware Detection (xmrig SHA256) and Container Drift both fire on exec, not on sustained runtime — xmrig is detected before it ever hits the memory cap.

**`debug-tools`**: modest limits (256 Mi / 200m) since it only runs `sleep infinity`. Defensive hygiene.

## Testing

- Detections should still fire (exec-based, not duration-based)
- `kubectl get pods` should remain stable through the entire attack sequence
- xmrig gets OOM-killed within the container cgroup; `orders-api` pod stays Running